### PR TITLE
Refactor how we expand all macros in context, allowing more complex defs

### DIFF
--- a/lib/alarmist/definition/definition.ex
+++ b/lib/alarmist/definition/definition.ex
@@ -1,6 +1,16 @@
 defmodule Alarmist.Definition do
   @moduledoc false
 
+  defp expand_expression(expr, caller) do
+    {_item, acc} =
+      Macro.postwalk(expr, nil, fn item, _acc ->
+        acc = process_node(item, caller)
+        {item, acc}
+      end)
+
+    acc
+  end
+
   defp process_node(item, _caller) when is_atom(item), do: Module.concat([item])
 
   defp process_node({:__aliases__, _, [_item]} = node, caller) do
@@ -11,18 +21,25 @@ defmodule Alarmist.Definition do
 
   defp process_node(number, _caller) when is_number(number), do: number
 
-  defp process_node({op, _meta, children}, caller) do
+  defp process_node({op, _meta, children} = node, caller) when is_list(children) do
     processed_children = Enum.map(children, fn child -> process_node(child, caller) end)
 
     case op do
-      :not -> [:not | processed_children]
-      :and -> [:and | processed_children]
-      :or -> [:or | processed_children]
-      :debounce -> [:debounce | processed_children]
-      :hold -> [:hold | processed_children]
-      :intensity -> [:intensity | processed_children]
+      :not ->
+        [:not | processed_children]
+
+      :and ->
+        [:and | processed_children]
+
+      :or ->
+        [:or | processed_children]
+
+      _ ->
+        Macro.expand(node, caller)
     end
   end
+
+  defp process_node(item, caller), do: Macro.expand(item, caller)
 
   @spec assert_not_defined(map(), number(), String.t()) :: no_return()
   def assert_not_defined(alarm_attr, line, file) do
@@ -31,6 +48,30 @@ defmodule Alarmist.Definition do
         line: line,
         file: file,
         description: "Cannot define multiple alarms in a single module!"
+    end
+  end
+
+  defmacro debounce(expression, time) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [time: time, expr_expanded: expr_expanded] do
+      [:debounce, expr_expanded, time]
+    end
+  end
+
+  defmacro hold(expression, time) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [time: time, expr_expanded: expr_expanded] do
+      [:hold, expr_expanded, time]
+    end
+  end
+
+  defmacro intensity(expression, count, time) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [count: count, time: time, expr_expanded: expr_expanded] do
+      [:intensity, expr_expanded, count, time]
     end
   end
 
@@ -47,25 +88,12 @@ defmodule Alarmist.Definition do
     end
   end
 
-  defmacro defalarm(do: {:__aliases__, _, [block]}) do
-    quote do
-      alarm_name = __MODULE__
-      compiled = Alarmist.Compiler.compile(alarm_name, Module.concat([unquote(block)]))
-      assert_not_defined(@__alarmist_alarm, __ENV__.line, __ENV__.file)
-      @__alarmist_alarm compiled
-    end
-  end
-
   defmacro defalarm(do: block) do
-    {_item, acc} =
-      Macro.postwalk(block, nil, fn item, _acc ->
-        acc = process_node(item, __CALLER__)
-        {item, acc}
-      end)
+    expr_expanded = expand_expression(block, __CALLER__)
 
     quote do
       alarm_name = __MODULE__
-      compiled = Alarmist.Compiler.compile(alarm_name, unquote(acc))
+      compiled = Alarmist.Compiler.compile(alarm_name, unquote(expr_expanded))
       assert_not_defined(@__alarmist_alarm, __ENV__.line, __ENV__.file)
       @__alarmist_alarm compiled
     end


### PR DESCRIPTION
Allows using module attributes and more complex expressions inside `defalarm`

example:

```elixir
defmodule TestDef do
  use Alarmist.Definition

  @attr_test 10_000

  defalarm do
    my_cool_variable = @attr_test + 100
    debounce(AlarmID1 or AlarmID2, my_cool_variable)
  end
end
```