### PR TITLE
Swap the handler after the supervision tree is up

### DIFF
--- a/lib/alarmist/application.ex
+++ b/lib/alarmist/application.ex
@@ -4,18 +4,26 @@ defmodule Alarmist.Application do
 
   @impl Application
   def start(_type, _args) do
+    # The handler must be installed after the PropertyTable is created. There
+    # is no stopping the Alarmist app cleanly once `Alarmist.Handler` has been
+    # registered.
+    children = [
+      {PropertyTable, name: Alarmist, matcher: Alarmist.Matcher},
+      {Task, &install_handler/0}
+    ]
+
+    opts = [strategy: :one_for_one, name: Alarmist.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  defp install_handler() do
     config = Application.get_all_env(:alarmist)
 
     :ok =
-      :gen_event.swap_sup_handler(
+      :gen_event.swap_handler(
         :alarm_handler,
         {:alarm_handler, :swap},
         {Alarmist.Handler, config}
       )
-
-    children = [{PropertyTable, name: Alarmist, matcher: Alarmist.Matcher}]
-
-    opts = [strategy: :one_for_one, name: Alarmist.Supervisor]
-    Supervisor.start_link(children, opts)
   end
 end


### PR DESCRIPTION
It was possible for alarms to be set before the PropertyTable was
created, and that would cause Alarmist to crash when it processed those
alarms.