### PR TITLE
Replace PropertyTable.Event with built-in type

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,23 +256,21 @@ Finally, we can exercise setting and clearing the alarm:
 iex> Demo.wifi_flap
 :ok
 iex> flush
-%PropertyTable.Event{
-  table: Alarmist,
-  property: [Demo.WiFiUnstable, :status],
-  value: :set,
+%Alarmist.Event{
+  alarm_id: Demo.WiFiUnstable,
+  state: :set,
   timestamp: -576460718306150542,
-  previous_value: nil,
+  previous_state: nil,
   previous_timestamp: nil
 }
 :ok
 # Wait ~60 seconds
 iex> flush
-%PropertyTable.Event{
-  table: Alarmist,
-  property: [Demo.WiFiUnstable, :status],
-  value: :clear,
+%Alarmist.Event{
+  alarm_id: Demo.WiFiUnstable,
+  state: :clear,
   timestamp: -576460658305612233,
-  previous_value: :set,
+  previous_state: :set,
   previous_timestamp: -576460718306150542
 }
 ```

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -48,12 +48,11 @@ defmodule Alarmist do
   Events will be delivered to the calling process as:
 
   ```elixir
-  %PropertyTable.Event{
-    table: Alarmist,
-    property: [TheAlarmId, :status],
-    value: :set,
+  %Alarmist.Event{
+    alarm_id: TheAlarmId,
+    state: :set,
     timestamp: -576460718306150542,
-    previous_value: nil,
+    previous_state: nil,
     previous_timestamp: nil
   }
   ```

--- a/lib/alarmist/application.ex
+++ b/lib/alarmist/application.ex
@@ -8,7 +8,10 @@ defmodule Alarmist.Application do
     # is no stopping the Alarmist app cleanly once `Alarmist.Handler` has been
     # registered.
     children = [
-      {PropertyTable, name: Alarmist, matcher: Alarmist.Matcher},
+      {PropertyTable,
+       name: Alarmist,
+       matcher: Alarmist.Matcher,
+       event_transformer: &Alarmist.Event.from_property_table/1},
       {Task, &install_handler/0}
     ]
 

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -1,0 +1,41 @@
+defmodule Alarmist.Event do
+  @moduledoc """
+  Struct sent to subscribers on property changes
+
+  * `:alarm_id` - which alarm
+  * `:state` - `:set` or `:clear`
+  * `:data` - alarm data if set or `nil` if cleared
+  * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
+  * `:previous_state` - the previous value (`nil` if this property is new)
+  * `:previous_timestamp` - the timestamp when the property changed to
+    `:previous_value`. Use this to calculate how long the property was the
+    previous value.
+  """
+  defstruct [:alarm_id, :state, :data, :timestamp, :previous_state, :previous_timestamp]
+
+  @type t() :: %__MODULE__{
+          alarm_id: Alarmist.alarm_id(),
+          state: Alarmist.alarm_state(),
+          data: any(),
+          previous_state: Alarmist.alarm_state(),
+          timestamp: integer(),
+          previous_timestamp: integer()
+        }
+
+  @doc false
+  @spec from_property_table(PropertyTable.Event.t()) :: t()
+  def from_property_table(%PropertyTable.Event{property: [alarm_id, :status]} = event) do
+    %__MODULE__{
+      alarm_id: alarm_id,
+      state: event.value,
+      data: nil,
+      timestamp: event.timestamp,
+      previous_state: event.previous_value,
+      previous_timestamp: event.previous_timestamp
+    }
+  end
+
+  def from_property_table(_) do
+    nil
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Alarmist.MixProject do
 
   defp deps do
     [
-      {:property_table, "~> 0.2.4"},
+      {:property_table, "~> 0.2.4", path: "~/git/nerves-project/property_table"},
       {:ex_doc, "~> 0.27", only: :docs, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
This makes it much easier to add supplemental alarm data to events since we're no longer constrained to the PropertyTable event type. It also cleans up alarm event handling code.

It's draft since a PropertyTable library is needed that supports event transformers.