### PR TITLE
Switch from PropertyTable events to a built-in one

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,29 +256,25 @@ Finally, we can exercise setting and clearing the alarm:
 iex> Demo.wifi_flap
 :ok
 iex> flush
-%PropertyTable.Event{
-  table: Alarmist,
-  property: [Demo.WiFiUnstable, :status],
-  value: :set,
-  timestamp: -576460718306150542,
-  previous_value: nil,
-  previous_timestamp: nil
+%Alarmist.Event{
+  id: Demo.WiFiUnstable,
+  state: :set,
+  description: nil,
+  timestamp: -576460712978320952,
+  previous_state: nil,
+  previous_timestamp: -576460751417398083
 }
 :ok
 # Wait ~60 seconds
 iex> flush
-%PropertyTable.Event{
-  table: Alarmist,
-  property: [Demo.WiFiUnstable, :status],
-  value: :clear,
-  timestamp: -576460658305612233,
-  previous_value: :set,
-  previous_timestamp: -576460718306150542
+%Alarmist.Event{
+  id: Demo.WiFiUnstable,
+  state: :clear,
+  timestamp: -576460652977733801,
+  previous_state: :set,
+  previous_timestamp: -576460712978320952
 }
 ```
-
-NOTE: The event format will likely change in the future to avoid exposing that
-Alarmist uses the PropertyTable library internally.
 
 ## License
 

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -48,18 +48,15 @@ defmodule Alarmist do
   Events will be delivered to the calling process as:
 
   ```elixir
-  %PropertyTable.Event{
-    table: Alarmist,
-    property: [TheAlarmId, :status],
-    value: :set,
-    timestamp: -576460718306150542,
-    previous_value: nil,
-    previous_timestamp: nil
+  %Alarmist.Event{
+    id: TheAlarmId,
+    state: :set,
+    description: nil,
+    timestamp: -576460712978320952,
+    previous_state: nil,
+    previous_timestamp: -576460751417398083
   }
   ```
-
-  This will almost certainly change in the future to avoid exposing that the
-  PropertyTable library is used to manage subscriptions.
   """
   @spec subscribe(alarm_id()) :: :ok
   def subscribe(alarm_id) when is_atom(alarm_id) do

--- a/lib/alarmist/application.ex
+++ b/lib/alarmist/application.ex
@@ -8,7 +8,10 @@ defmodule Alarmist.Application do
     # is no stopping the Alarmist app cleanly once `Alarmist.Handler` has been
     # registered.
     children = [
-      {PropertyTable, name: Alarmist, matcher: Alarmist.Matcher},
+      {PropertyTable,
+       name: Alarmist,
+       matcher: Alarmist.Matcher,
+       event_transformer: &Alarmist.Event.from_property_table/1},
       {Task, &install_handler/0}
     ]
 

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -1,0 +1,41 @@
+defmodule Alarmist.Event do
+  @moduledoc """
+  Struct sent to subscribers on property changes
+
+  * `:id` - which alarm
+  * `:state` - `:set` or `:clear`
+  * `:description` - alarm description or `nil` when the alarm has been cleared
+  * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
+  * `:previous_state` - the previous value (`nil` if this property is new)
+  * `:previous_timestamp` - the timestamp when the property changed to
+    `:previous_state`. Use this to calculate how long the property was the
+    previous state.
+  """
+  defstruct [:id, :state, :description, :timestamp, :previous_state, :previous_timestamp]
+
+  @type t() :: %__MODULE__{
+          id: Alarmist.alarm_id(),
+          state: Alarmist.alarm_state(),
+          description: any(),
+          previous_state: Alarmist.alarm_state() | nil,
+          timestamp: integer(),
+          previous_timestamp: integer()
+        }
+
+  @doc false
+  @spec from_property_table(PropertyTable.Event.t()) :: t() | nil
+  def from_property_table(%PropertyTable.Event{property: [alarm_id, :status]} = event) do
+    %__MODULE__{
+      id: alarm_id,
+      state: event.value,
+      description: nil,
+      timestamp: event.timestamp,
+      previous_state: event.previous_value,
+      previous_timestamp: event.previous_timestamp
+    }
+  end
+
+  def from_property_table(_) do
+    nil
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Alarmist.MixProject do
 
   defp deps do
     [
-      {:property_table, "~> 0.2.4"},
+      {:property_table, "~> 0.2.6"},
       {:ex_doc, "~> 0.27", only: :docs, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.0", "74bb8348c9b3a51d5c589bf5aebb0466a84b33274150e3b6ece1da45584afc82", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49159b7d7d999e836bedaf09dcf35ca18b312230cf901b725a64f3f42e407983"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "property_table": {:hex, :property_table, "0.2.5", "72567da62711d0b8b517990eadbe76685e5b02ed90ad5a2e48ae6f3a7922cf64", [:mix], [], "hexpm", "abfd4ce4dd9a7a6d39c0a35b177c09dc9aba5af0eb1f93cc28919e31d5f8bbab"},
+  "property_table": {:hex, :property_table, "0.2.6", "41fb5e94cabc360827213abcf0b2ae255a22f834f86828df63001fccbaf3d319", [:mix], [], "hexpm", "7545a31384eb9e98da91a54cfa4ad7cb8b38ba556d6b7051c3f7d9f9f4caf567"},
 }

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -14,20 +14,18 @@ defmodule AlarmistTest do
 
     :alarm_handler.set_alarm({TestAlarm, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :set
     }
 
     assert TestAlarm in Alarmist.current_alarms()
 
     :alarm_handler.clear_alarm(TestAlarm)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :clear
     }
 
     refute_receive _
@@ -39,18 +37,16 @@ defmodule AlarmistTest do
 
     :alarm_handler.set_alarm(TestAlarm)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :set
     }
 
     :alarm_handler.clear_alarm(TestAlarm)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :clear
     }
 
     refute_receive _
@@ -83,18 +79,16 @@ defmodule AlarmistTest do
 
     :alarm_handler.set_alarm({AlarmId2, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :set
     }
 
     :alarm_handler.clear_alarm(AlarmId2)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: TestAlarm,
+      state: :clear
     }
 
     :alarm_handler.clear_alarm(AlarmId1)
@@ -117,10 +111,9 @@ defmodule AlarmistTest do
 
     Alarmist.add_synthetic_alarm(MyAlarm6)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [MyAlarm6, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: MyAlarm6,
+      state: :set
     }
 
     Alarmist.remove_synthetic_alarm(MyAlarm6)
@@ -140,18 +133,16 @@ defmodule AlarmistTest do
 
     :alarm_handler.set_alarm({AlarmId10, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [MyAlarm7, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: MyAlarm7,
+      state: :set
     }
 
     Alarmist.remove_synthetic_alarm(MyAlarm7)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [MyAlarm7, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: MyAlarm7,
+      state: :clear
     }
   end
 
@@ -170,34 +161,30 @@ defmodule AlarmistTest do
     Alarmist.add_synthetic_alarm(HoldAlarm)
     :alarm_handler.set_alarm({AlarmId1, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [HoldAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: HoldAlarm,
+      state: :set
     }
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId1, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: AlarmId1,
+      state: :set
     }
 
     :alarm_handler.clear_alarm(AlarmId1)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId1, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: AlarmId1,
+      state: :clear
     }
 
     refute_receive _
 
     Process.sleep(250)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [HoldAlarm, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: HoldAlarm,
+      state: :clear
     }
 
     Alarmist.remove_synthetic_alarm(MyAlarms2.HoldAlarm)
@@ -222,17 +209,15 @@ defmodule AlarmistTest do
 
     :alarm_handler.set_alarm({AlarmId1, 3})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [IntensityAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: IntensityAlarm,
+      state: :set
     }
 
     # It will go away in 250 ms
-    assert_receive %PropertyTable.Event{
-                     table: Alarmist,
-                     property: [IntensityAlarm, :status],
-                     value: :clear
+    assert_receive %Alarmist.Event{
+                     id: IntensityAlarm,
+                     state: :clear
                    },
                    500
 
@@ -255,20 +240,18 @@ defmodule AlarmistTest do
     # Test the transient case
     :alarm_handler.set_alarm({AlarmId2, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId2, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: AlarmId2,
+      state: :set
     }
 
     refute_received _
 
     :alarm_handler.clear_alarm(AlarmId2)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId2, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: AlarmId2,
+      state: :clear
     }
 
     refute_receive _
@@ -276,34 +259,30 @@ defmodule AlarmistTest do
     # Test the long alarm case
     :alarm_handler.set_alarm({AlarmId2, []})
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId2, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: AlarmId2,
+      state: :set
     }
 
     refute_receive _
 
     Process.sleep(100)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [DebounceAlarm, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: DebounceAlarm,
+      state: :set
     }
 
     :alarm_handler.clear_alarm(AlarmId2)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [AlarmId2, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: DebounceAlarm,
+      state: :clear
     }
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [DebounceAlarm, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: AlarmId2,
+      state: :clear
     }
 
     Alarmist.remove_synthetic_alarm(DebounceAlarm)
@@ -321,19 +300,17 @@ defmodule AlarmistTest do
     Alarmist.subscribe(TestAlarm2)
     Alarmist.add_synthetic_alarm(TestAlarm2)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm2, :status],
-      value: :set
+    assert_receive %Alarmist.Event{
+      id: TestAlarm2,
+      state: :set
     }
 
     :alarm_handler.set_alarm(Id2)
     :alarm_handler.set_alarm(Id3)
 
-    assert_receive %PropertyTable.Event{
-      table: Alarmist,
-      property: [TestAlarm2, :status],
-      value: :clear
+    assert_receive %Alarmist.Event{
+      id: TestAlarm2,
+      state: :clear
     }
 
     refute_receive _


### PR DESCRIPTION
BACKWARDS INCOMPATIBLE CHANGE

This fixes the TODO to create a custom event type for Alarmist. The main
advantage here is to make Alarmist easier to use since the PropertyTable
internals aren't exposed.  The second reason is that the PropertyTable
schema is changing and if we're going to break the API, we might as well
just do it once.
