### PR TITLE
Simplify PropertyTable use

### DIFF
--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -60,7 +60,7 @@ defmodule Alarmist do
   """
   @spec subscribe(alarm_id()) :: :ok
   def subscribe(alarm_id) when is_atom(alarm_id) do
-    PropertyTable.subscribe(Alarmist, [alarm_id, :status])
+    PropertyTable.subscribe(Alarmist, [alarm_id])
   end
 
   @doc """
@@ -68,7 +68,7 @@ defmodule Alarmist do
   """
   @spec unsubscribe(alarm_id()) :: :ok
   def unsubscribe(alarm_id) when is_atom(alarm_id) do
-    PropertyTable.unsubscribe(Alarmist, [alarm_id, :status])
+    PropertyTable.unsubscribe(Alarmist, [alarm_id])
   end
 
   @doc """
@@ -76,9 +76,11 @@ defmodule Alarmist do
   """
   @spec current_alarms() :: [alarm_id()]
   def current_alarms() do
-    PropertyTable.match(Alarmist, [:_, :status])
-    |> Enum.filter(fn {_, status} -> status == :set end)
-    |> Enum.map(fn {[alarm_id, _], _} -> alarm_id end)
+    PropertyTable.get_all(Alarmist)
+    |> Enum.flat_map(fn
+      {[alarm_id], {:set, _}} -> [alarm_id]
+      _ -> []
+    end)
   end
 
   @doc """

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -6,7 +6,7 @@ defmodule Alarmist.Event do
   * `:state` - `:set` or `:clear`
   * `:description` - alarm description or `nil` when the alarm has been cleared
   * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
-  * `:previous_state` - the previous value (`nil` if this property is new)
+  * `:previous_state` - the previous value (`nil` if no previous information)
   * `:previous_timestamp` - the timestamp when the property changed to
     `:previous_state`. Use this to calculate how long the property was the
     previous state.
@@ -23,19 +23,21 @@ defmodule Alarmist.Event do
         }
 
   @doc false
-  @spec from_property_table(PropertyTable.Event.t()) :: t() | nil
-  def from_property_table(%PropertyTable.Event{property: [alarm_id, :status]} = event) do
+  @spec from_property_table(PropertyTable.Event.t()) :: t()
+  def from_property_table(%PropertyTable.Event{property: [alarm_id]} = event) do
+    {state, description} = property_to_info(event.value)
+    {previous_state, _} = property_to_info(event.previous_value)
+
     %__MODULE__{
       id: alarm_id,
-      state: event.value,
-      description: nil,
+      state: state,
+      description: description,
       timestamp: event.timestamp,
-      previous_state: event.previous_value,
+      previous_state: previous_state,
       previous_timestamp: event.previous_timestamp
     }
   end
 
-  def from_property_table(_) do
-    nil
-  end
+  defp property_to_info({state, description}), do: {state, description}
+  defp property_to_info(nil), do: {nil, nil}
 end

--- a/lib/alarmist/handler.ex
+++ b/lib/alarmist/handler.ex
@@ -59,7 +59,7 @@ defmodule Alarmist.Handler do
   end
 
   defp lookup(alarm_id) do
-    PropertyTable.get(Alarmist, [alarm_id, :status], :clear)
+    PropertyTable.get(Alarmist, [alarm_id], {:clear, nil})
   end
 
   @doc """
@@ -134,16 +134,12 @@ defmodule Alarmist.Handler do
   #   # of an inconsistent view of the table.
   # end
 
-  defp run_side_effect({:set, alarm_id}) do
-    PropertyTable.put(Alarmist, [alarm_id, :status], :set)
+  defp run_side_effect({:set, alarm_id, description}) do
+    PropertyTable.put(Alarmist, [alarm_id], {:set, description})
   end
 
-  defp run_side_effect({:clear, alarm_id}) do
-    PropertyTable.put(Alarmist, [alarm_id, :status], :clear)
-  end
-
-  defp run_side_effect({:set_description, alarm_id, description}) do
-    PropertyTable.put(Alarmist, [alarm_id, :description], description)
+  defp run_side_effect({:clear, alarm_id, _}) do
+    PropertyTable.put(Alarmist, [alarm_id], {:clear, nil})
   end
 
   defp run_side_effect({:start_timer, alarm_id, timeout, what, params}) do


### PR DESCRIPTION
This combines alarm state and description data into one PropertyTable
property. This removes a race when getting state and descriptions where
code would get both and one would change partway. With only one row per
alarm, there's no issue.

This also allows code to be simplified throughout. The action list
optimization was simplified to be easier to verify correctness. The
optimization is still tricky, so more tests were added.
