### PR TITLE
Introduce :unknown state when the alarm status isn't know

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ iex> flush
   state: :set,
   description: nil,
   timestamp: -576460712978320952,
-  previous_state: nil,
+  previous_state: :unknown,
   previous_timestamp: -576460751417398083
 }
 :ok

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -62,7 +62,7 @@ defmodule Alarmist do
     state: :set,
     description: nil,
     timestamp: -576460712978320952,
-    previous_state: nil,
+    previous_state: :unknown,
     previous_timestamp: -576460751417398083
   }
   ```

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -6,7 +6,7 @@ defmodule Alarmist.Event do
   * `:state` - `:set` or `:clear`
   * `:description` - alarm description or `nil` when the alarm has been cleared
   * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
-  * `:previous_state` - the previous value (`nil` if no previous information)
+  * `:previous_state` - the previous value (`:unknown` if no previous information)
   * `:previous_timestamp` - the timestamp when the property changed to
     `:previous_state`. Use this to calculate how long the property was the
     previous state.
@@ -17,7 +17,7 @@ defmodule Alarmist.Event do
           id: Alarmist.alarm_id(),
           state: Alarmist.alarm_state(),
           description: Alarmist.alarm_description(),
-          previous_state: Alarmist.alarm_state() | nil,
+          previous_state: Alarmist.alarm_state() | :unknown,
           timestamp: integer(),
           previous_timestamp: integer()
         }
@@ -39,5 +39,5 @@ defmodule Alarmist.Event do
   end
 
   defp property_to_info({state, description}), do: {state, description}
-  defp property_to_info(nil), do: {nil, nil}
+  defp property_to_info(nil), do: {:unknown, nil}
 end

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -19,7 +19,7 @@ defmodule AlarmistTest do
                      state: :set,
                      previous_state: previous_state
                    }
-                   when previous_state in [nil, :clear]
+                   when previous_state in [:unknown, :clear]
 
     assert {TestAlarm, nil} in Alarmist.get_alarms()
     assert TestAlarm in Alarmist.get_alarm_ids()
@@ -50,7 +50,7 @@ defmodule AlarmistTest do
                      description: [],
                      previous_state: previous_state
                    }
-                   when previous_state in [nil, :clear]
+                   when previous_state in [:unknown, :clear]
 
     :alarm_handler.clear_alarm(TestAlarm)
 
@@ -76,7 +76,7 @@ defmodule AlarmistTest do
                      description: :test_description,
                      previous_state: previous_state
                    }
-                   when previous_state in [nil, :clear]
+                   when previous_state in [:unknown, :clear]
 
     # Need to pause for description write side effect
     Process.sleep(100)


### PR DESCRIPTION
This replaces the use of `nil`'s to indicate unknown. The goal is to
give a intentional unknown result to avoid any guesses if the `nil` was
a coding error. This only affects the `previous_state` right now.
