### PR TITLE
Provide a type for alarm descriptions

### DIFF
--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -19,6 +19,15 @@ defmodule Alarmist do
   @type alarm_id() :: atom()
 
   @typedoc """
+  Alarm description
+
+  This is optional supplemental information about the alarm. It could contain
+  more information about why it was set. Don't use it to differentiate between
+  alarms. Use the alarm ID for that.
+  """
+  @type alarm_description() :: any()
+
+  @typedoc """
   Alarm information
 
   Calls to `:alarm_handler.set_alarm/1` pass an alarm identifier and
@@ -28,7 +37,7 @@ defmodule Alarmist do
   `:alarm_handler.set_alarm/1` doesn't enforce the use of 2-tuples. Alarmist
   normalizes non-2-tuple alarms so that they have empty descriptions.
   """
-  @type alarm() :: {alarm_id(), any()}
+  @type alarm() :: {alarm_id(), alarm_description()}
 
   @typedoc """
   Alarm state

--- a/lib/alarmist/engine.ex
+++ b/lib/alarmist/engine.ex
@@ -4,13 +4,14 @@ defmodule Alarmist.Engine do
   """
 
   @type action() ::
-          {:set, Alarmist.alarm_id(), any()}
+          {:set, Alarmist.alarm_id(), Alarmist.alarm_description()}
           | {:clear, Alarmist.alarm_id()}
           | {:start_timer, Alarmist.alarm_id(), pos_integer(), Alarmist.alarm_state(),
              reference()}
           | {:cancel_timer, reference()}
 
-  @type alarm_lookup_fun() :: (Alarmist.alarm_id() -> {Alarmist.alarm_state(), any()})
+  @type alarm_lookup_fun() :: (Alarmist.alarm_id() ->
+                                 {Alarmist.alarm_state(), Alarmist.alarm_description()})
 
   defstruct [
     :rules,
@@ -61,7 +62,7 @@ defmodule Alarmist.Engine do
   @doc """
   Report that an alarm_id has changed state
   """
-  @spec set_alarm(t(), Alarmist.alarm_id(), any()) :: t()
+  @spec set_alarm(t(), Alarmist.alarm_id(), Alarmist.alarm_description()) :: t()
   def set_alarm(engine, alarm_id, description) when is_atom(alarm_id) do
     engine
     |> cache_put(alarm_id, :set, description)
@@ -211,7 +212,8 @@ defmodule Alarmist.Engine do
   end
 
   @doc false
-  @spec cache_get(t(), Alarmist.alarm_id()) :: {t(), {Alarmist.alarm_state(), any()}}
+  @spec cache_get(t(), Alarmist.alarm_id()) ::
+          {t(), {Alarmist.alarm_state(), Alarmist.alarm_description()}}
   def cache_get(engine, alarm_id) do
     case Map.fetch(engine.cache, alarm_id) do
       {:ok, result} ->
@@ -229,7 +231,8 @@ defmodule Alarmist.Engine do
 
   IMPORTANT: Rules are evaluated on the next call to `run/2` if there was a change.
   """
-  @spec cache_put(t(), Alarmist.alarm_id(), Alarmist.alarm_state(), any()) :: t()
+  @spec cache_put(t(), Alarmist.alarm_id(), Alarmist.alarm_state(), Alarmist.alarm_description()) ::
+          t()
   def cache_put(engine, alarm_id, alarm_state, description) do
     {engine, current_state} = cache_get(engine, alarm_id)
 

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -16,7 +16,7 @@ defmodule Alarmist.Event do
   @type t() :: %__MODULE__{
           id: Alarmist.alarm_id(),
           state: Alarmist.alarm_state(),
-          description: any(),
+          description: Alarmist.alarm_description(),
           previous_state: Alarmist.alarm_state() | nil,
           timestamp: integer(),
           previous_timestamp: integer()


### PR DESCRIPTION
This makes some of the specs easier to read since you don't need to
figure out the intention behind the any.
