### PR TITLE
Add function to get AST from `defalarm`

### DIFF
--- a/lib/alarmist/definition.ex
+++ b/lib/alarmist/definition.ex
@@ -104,12 +104,14 @@ defmodule Alarmist.Definition do
           description: "Cannot define multiple alarms in a single module!"
       end
 
+      @alarmist_alarm_def unquote(Macro.to_string(block))
       @alarmist_alarm Alarmist.Compiler.compile(__MODULE__, unquote(expr_expanded))
     end
   end
 
   defmacro __before_compile__(env) do
     alarm = Module.get_attribute(env.module, :alarmist_alarm)
+    alarm_def = Module.get_attribute(env.module, :alarmist_alarm_def)
 
     if !alarm do
       raise CompileError,
@@ -119,6 +121,10 @@ defmodule Alarmist.Definition do
     end
 
     quote do
+      def __get_alarm_def() do
+        unquote(alarm_def)
+      end
+
       def __get_alarm() do
         unquote(Macro.escape(alarm))
       end

--- a/test/alarmist/defalarm_test.exs
+++ b/test/alarmist/defalarm_test.exs
@@ -16,6 +16,7 @@ defmodule Alarmist.DefAlarmTest do
 
     expected_result = [{Alarmist.Ops, :copy, [IdentityTest, MyAlarmId]}]
     assert IdentityTest.__get_alarm() == expected_result
+    assert IdentityTest.__get_alarm_def() == "MyAlarmId"
   end
 
   test "and" do
@@ -29,6 +30,7 @@ defmodule Alarmist.DefAlarmTest do
 
     expected_result = [{Alarmist.Ops, :logical_and, [AndTest, AlarmId1, AlarmId2]}]
     assert AndTest.__get_alarm() == expected_result
+    assert AndTest.__get_alarm_def() == "AlarmId1 and AlarmId2"
   end
 
   test "not" do
@@ -42,6 +44,7 @@ defmodule Alarmist.DefAlarmTest do
 
     expected_result = [{Alarmist.Ops, :logical_not, [NotTest, AlarmId1]}]
     assert NotTest.__get_alarm() == expected_result
+    assert NotTest.__get_alarm_def() == "not AlarmId1"
   end
 
   test "debounce" do
@@ -55,6 +58,7 @@ defmodule Alarmist.DefAlarmTest do
 
     expected_result = [{Alarmist.Ops, :debounce, [DebounceTest, AlarmId1, 1000]}]
     assert DebounceTest.__get_alarm() == expected_result
+    assert DebounceTest.__get_alarm_def() == "debounce(AlarmId1, 1000)"
   end
 
   test "hold" do
@@ -100,6 +104,7 @@ defmodule Alarmist.DefAlarmTest do
     ]
 
     assert AndOrTest.__get_alarm() == expected_result
+    assert AndOrTest.__get_alarm_def() == "AlarmId1 or (AlarmId2 and AlarmId3)"
   end
 
   test "compound with not" do


### PR DESCRIPTION
Alarms created using `defalarm/1` now have a `__get_alarm_def/0` function
that returns a string representation of the AST used to create the
alarm.
