### PR TITLE
Fix remove_synthetic_alarm to remove the right alarm

### DIFF
--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -168,13 +168,7 @@ defmodule Alarmist do
   end
 
   @doc """
-  Manually add a rule-based alarm
-
-  Use this when not using `defalarm`.
-
-  After this call, Alarmist will watch for alarms to be set based on the
-  supplied rules and set or clear the specified alarm ID. The alarm ID
-  needs to be unique.
+  Remove a rule-based alarm
   """
   @spec remove_synthetic_alarm(Alarmist.alarm_id()) :: :ok
   def remove_synthetic_alarm(alarm_id) when is_atom(alarm_id) do

--- a/lib/alarmist/engine.ex
+++ b/lib/alarmist/engine.ex
@@ -216,7 +216,7 @@ defmodule Alarmist.Engine do
 
   defp unlink_rules(rules, synthetic_alarm_id) do
     rules
-    |> Enum.filter(fn {alarm_id, _rule} -> alarm_id == synthetic_alarm_id end)
+    |> Enum.reject(fn {alarm_id, _rule} -> alarm_id == synthetic_alarm_id end)
   end
 
   @doc false


### PR DESCRIPTION
This doesn't include unit tests since I cherry-picked it out of another
branch with a lot of unit test updates and didn't want to deal with
the conflicts.
