### PR TITLE
Many breaking renames 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ being set:
 
 ```elixir
 defmodule MyNewAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     InterestingAlarm1 and InterestingAlarm2
@@ -111,7 +111,7 @@ the naming of alarms between projects.
 
 ```elixir
 defmodule IdenticalAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     SomeOtherAlarmName
@@ -127,7 +127,7 @@ chance that the alarm goes away on its own.
 
 ```elixir
 defmodule RealProblemAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     # Set this module's alarm when FlakyAlarm has been set for at for 5 seconds
@@ -145,7 +145,7 @@ alarm lets other code or alarms change their behavior as well.
 
 ```elixir
 defmodule LongerAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     # Set the alarm for at least 3 seconds whenever FlakyAlarm
@@ -164,7 +164,7 @@ for a short time when it flaps too much. Some people call this a penalty box.
 
 ```elixir
 defmodule IntensityThresholdAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     # Set when raised and cleared >= 5 times in 3 seconds
@@ -181,7 +181,7 @@ tracks exactly what you want.
 
 ```elixir
 defmodule IntensityThresholdAlarm do
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   defalarm do
     (Alarm1 or Alarm2) and intensity(FlakyAlarm, 5, 10_000)
@@ -206,7 +206,7 @@ defmodule Demo.WiFiUnstable do
   @moduledoc """
   Alarm for when WiFi bounces too frequently
   """
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   # WiFi must be down for at least 15 seconds or flapped 2 times in 60 seconds
   defalarm do

--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ minimum amount of time. `Alarmist` can also raise an alarm if the network is
 bouncing up and down a lot since that's also problematic, but in a way that the
 minimum time criteria wouldn't detect.
 
-To make synthetic alarms easy to create, `Alarmist` provides the `defalarm`
+To make synthetic alarms easy to create, `Alarmist` provides the `alarm_if`
 macro. The general form is to create a module with the name of the synthetic
-alarm you're creating and then use `defalarm` to express the criteria for it
+alarm you're creating and then use `alarm_if` to express the criteria for it
 being set:
 
 ```elixir
 defmodule MyNewAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     InterestingAlarm1 and InterestingAlarm2
   end
 end
@@ -113,7 +113,7 @@ the naming of alarms between projects.
 defmodule IdenticalAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     SomeOtherAlarmName
   end
 end
@@ -129,7 +129,7 @@ chance that the alarm goes away on its own.
 defmodule RealProblemAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     # Set this module's alarm when FlakyAlarm has been set for at for 5 seconds
     debounce(FlakyAlarm, 5_000)
   end
@@ -147,7 +147,7 @@ alarm lets other code or alarms change their behavior as well.
 defmodule LongerAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     # Set the alarm for at least 3 seconds whenever FlakyAlarm
     hold(FlakyAlarm, 3_000)
   end
@@ -166,7 +166,7 @@ for a short time when it flaps too much. Some people call this a penalty box.
 defmodule IntensityThresholdAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     # Set when raised and cleared >= 5 times in 3 seconds
     intensity(FlakyAlarm, 5, 3_000)
   end
@@ -183,7 +183,7 @@ tracks exactly what you want.
 defmodule IntensityThresholdAlarm do
   use Alarmist.Alarm
 
-  defalarm do
+  alarm_if do
     (Alarm1 or Alarm2) and intensity(FlakyAlarm, 5, 10_000)
   end
 end
@@ -209,7 +209,7 @@ defmodule Demo.WiFiUnstable do
   use Alarmist.Alarm
 
   # WiFi must be down for at least 15 seconds or flapped 2 times in 60 seconds
-  defalarm do
+  alarm_if do
     debounce(Demo.WiFiDown, :timer.seconds(15)) or
       intensity(Demo.WiFiDown, 2, :timer.seconds(60))
   end

--- a/README.md
+++ b/README.md
@@ -6,25 +6,26 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/smartrent/alarmist)](https://api.reuse.software/info/github.com/smartrent/alarmist)
 
 Alarmist extends Erlang's [Alarm
-Handler](https://www.erlang.org/doc/man/alarm_handler) to manage, subscribe to,
-and create synthetic alarms. Code that sets and clears alarms need only depend
-on `:alarm_handler`. Alarmist is for the side that has to deal with alarms.
+Handler](https://www.erlang.org/doc/man/alarm_handler) to support
+subscriptions, conditional logic for triggering new alarms, and more. Alarmist
+aims to be unintrusive and supports existing conventions for naming and using
+alarms. Only the end user's application need depend on Alarmist.
 
 ## What are alarms
 
 Alarms are different from events. While events can convey any information, an
 alarm conveys a boolean state. The alarm can either be `set` or `clear`. Code
 should always be able to know the state of the alarm. With events, you either
-get the event or not. There may be ways of obtaining the event when it's missed,
-but with alarms there's an expectation that the alarm state is always
+get the event or not. There may be ways of obtaining the event when it's
+missed, but with alarms there's an expectation that the alarm state is always
 accessible.
 
 Erlang's Alarm Handler allows code that sets alarms to include supplementary
-information called `AlarmDescription`. This is purely informational. If an alarm
-is set more than once, only the latest description is available. It is not
-useful for differentiating alarms. For example, a network disconnected alarm
-should incorporate the network interface name (`eth0`) into the `AlarmId` rather
-than the `AlarmDescription`.
+information called `AlarmDescription`. This is purely informational. If an
+alarm is set more than once, only the latest description is available. It is
+not useful for differentiating alarms. For example, a network disconnected
+alarm should incorporate the network interface name (`eth0`) into the `AlarmId`
+rather than the `AlarmDescription`.
 
 ## When to use alarms
 
@@ -32,10 +33,10 @@ Alarms are one tool in the fault management toolbox. They give a name to
 persistent conditions that are involved with non-local remediation to clear.
 
 Persistent in this sense means that the alarm continues to exist until reported
-otherwise. It is not transient. For example, a supervised GenServer that crashes
-is a transient fault since its supervisor is going to restart it. An issue like
-a remote server no longer being reachable is persistent. It may become reachable
-in a few seconds or hours or more.
+otherwise. It is not transient. For example, a supervised GenServer that
+crashes is a transient fault since its supervisor is going to restart it. An
+issue like a remote server no longer being reachable is persistent. It may
+become reachable in a few seconds or hours or more.
 
 Non-local remediation means that the code that sets the alarm does so to either
 help or get help from somewhere else like another library or a person. For
@@ -47,15 +48,15 @@ internet is unreachable so that UI code could show the issue to a nearby human.
 Erlang's Alarm Handler allows `AlarmId`'s to be any Erlang term. While super
 flexible, it's also helpful to have a convention.
 
-For Elixir code, name alarms as you would a module. If you have helper functions
-for `AlarmDescription` data, then put those functions in a `defmodule` of the
-same name as the alarm. This is optional, so there's no need to create an empty
-module if you don't have helper functions.
+For Elixir code, name alarms as you would a module. If you have helper
+functions for `AlarmDescription` data, then put those functions in a
+`defmodule` of the same name as the alarm. This is optional, so there's no need
+to create an empty module if you don't have helper functions.
 
 For libraries, alarms are public API. There's no explicit place for alarms in
 Hex documentation, so add them where you think best. The important parts are to
-document the alarms name, when it's set and cleared, and the type and content of
-the `AlarmDescription` data.
+document the alarms name, when it's set and cleared, and the type and content
+of the `AlarmDescription` data.
 
 Erlang code should use Erlang conventions for naming modules.
 
@@ -63,30 +64,27 @@ Erlang code should use Erlang conventions for naming modules.
 supported by `Alarmist`, but probably will be added. I.e. `{NetworkDown,
 "eth0"}`**
 
-## Synthetic alarms
+## Managed alarms
 
-One of the major features of `Alarmist` is to support creating new alarms that
-get set and cleared based on the status of other alarms. This simplifies alarm
-handling code since it's often the case that you don't want to trigger a
-remediation immediately or a remediation may only be useful if some combination
-of alarms are set. Another advantage of creating synthetic alarms is that it
-increases the visibility of when these more complex alarms trigger so that you
-don't need to dig through the alarm handling code to know whether conditions
-have met the remediation criteria or not.
+One of the major features of `Alarmist` is the ability to compose alarms via
+boolean logic. This simplifies alarm handling code since it's often the case
+that you don't want to trigger a remediation immediately or a remediation may
+only be useful if some combination of alarms are set. Another advantage of
+creating these "managed" alarms is code simplification where the Alarmist DSL
+can make one-liners out of many real world alarm scenarios.
 
-As before, networking issues make good examples. Home and business networks have
-some normal flakiness that doesn't require remediation. Sometimes just waiting a
-bit resolves a situation. Code that detects a network outage can simply set an
-alarm stating it is down. `Alarmist` provides primitives for creating a
-synthetic alarm that doesn't get set unless the network is down longer than a
-minimum amount of time. `Alarmist` can also raise an alarm if the network is
-bouncing up and down a lot since that's also problematic, but in a way that the
-minimum time criteria wouldn't detect.
+As before, networking issues make good examples. Home and business networks
+have some normal hiccups that don't require remediation. Sometimes just waiting
+a bit makes the network start working again. Code that detects a network outage
+can simply set an alarm stating it is down. `Alarmist` provides primitives for
+creating a managed alarm that doesn't get set until the network is down longer
+than a user-specified duration. `Alarmist` can also raise that alarm if the
+network bounces up and down frequently since that's also problematic, but in a
+way that the minimum time criteria wouldn't detect.
 
-To make synthetic alarms easy to create, `Alarmist` provides the `alarm_if`
-macro. The general form is to create a module with the name of the synthetic
-alarm you're creating and then use `alarm_if` to express the criteria for it
-being set:
+To compose alarms using boolean logic, `Alarmist` provides the `alarm_if`
+macro. The general form is to create an Elixir module with the name of the
+managed alarm and then use `alarm_if` to express the criteria for it being set:
 
 ```elixir
 defmodule MyNewAlarm do
@@ -98,10 +96,10 @@ defmodule MyNewAlarm do
 end
 ```
 
-In this example, `MyNewAlarm` will be set only when both `InterestingAlarm1` and
-`InterestingAlarm2` are set.
+In this example, `Alarmist` will set `MyNewAlarm` only when both
+`InterestingAlarm1` and `InterestingAlarm2` are set.
 
-The following sections describe the operators available for synthetic alarms.
+The following sections describe the operators available for managed alarms.
 
 ### Identity
 
@@ -138,10 +136,10 @@ end
 
 ### Hold
 
-The `hold/2` function specifies a minimum amount of time for the new alarm to be
-set. For example, if an alarm triggers an indicator on a UI, then it may need to
-stay on for a minimum duration. While the UI could have the timer, creating an
-alarm lets other code or alarms change their behavior as well.
+The `hold/2` function specifies a minimum amount of time for the new alarm to
+be set. For example, if an alarm triggers an indicator on a UI, then it may
+need to stay on for a minimum duration. While the UI could have the timer,
+creating an alarm lets other code or alarms change their behavior as well.
 
 ```elixir
 defmodule LongerAlarm do
@@ -193,13 +191,13 @@ end
 
 The following example shows how to define an alarm that WiFi is unstable based
 on a alarm that says when WiFi is down. This is a real life example of an
-embedded device with an expensive backup cellular connection. WiFi can be flaky,
-though, so you wouldn't want to turn on the cellular connection right when WiFi
-goes down since that might be a hiccup.
+embedded device with an expensive backup cellular connection. WiFi can be
+flaky, though, so you wouldn't want to turn on the cellular connection right
+when WiFi goes down since that might be a hiccup.
 
-The following code defines a synthetic alarm for unstable WiFi,
-`Demo.WiFiUnstable`. The timeouts are short to make it easier to copy/paste into
-an IEx prompt and manually run.
+The following code defines a managed alarm for unstable WiFi,
+`Demo.WiFiUnstable`. The timeouts are short to make it easier to copy/paste
+into an IEx prompt and manually run.
 
 ```elixir
 defmodule Demo.WiFiUnstable do
@@ -236,12 +234,12 @@ defmodule Demo do
 end
 ```
 
-Now that we have alarm logic and helpers defined the synthetic alarm needs to be
+Now that we have alarm logic and helpers defined the managed alarm needs to be
 registered:
 
 ```elixir
   # ... normally in an Application.start or other code that runs on init ...
-  Alarmist.add_synthetic_alarm(Demo.WiFiUnstable)
+  Alarmist.add_managed_alarm(Demo.WiFiUnstable)
 ```
 
 Then subscribe for notifications:

--- a/examples/wifi_demo/README.md
+++ b/examples/wifi_demo/README.md
@@ -19,7 +19,7 @@ seconds) or has bounced too many times in a minute. We use the Alarmist alarm
 DSL to do this:
 
 ```elixir
-defalarm do
+alarm_if do
   debounce(WiFiDemo.WiFiDown, :timer.seconds(15)) or
     intensity(WiFiDemo.WiFiDown, 3, :timer.seconds(60))
 end

--- a/examples/wifi_demo/lib/wifi_demo/application.ex
+++ b/examples/wifi_demo/lib/wifi_demo/application.ex
@@ -8,7 +8,7 @@ defmodule WiFiDemo.Application do
       {WiFiDemo.Fixer, []}
     ]
 
-    Alarmist.add_synthetic_alarm(WiFiDemo.WiFiUnstable)
+    Alarmist.add_managed_alarm(WiFiDemo.WiFiUnstable)
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/examples/wifi_demo/lib/wifi_demo/wifi_unstable.ex
+++ b/examples/wifi_demo/lib/wifi_demo/wifi_unstable.ex
@@ -5,7 +5,7 @@ defmodule WiFiDemo.WiFiUnstable do
   use Alarmist.Alarm
 
   # WiFi must be down for at least 15 seconds or flapped 3 times in 60 seconds
-  defalarm do
+  alarm_if do
     debounce(WiFiDemo.WiFiDown, :timer.seconds(15)) or
       intensity(WiFiDemo.WiFiDown, 3, :timer.seconds(60))
   end

--- a/examples/wifi_demo/lib/wifi_demo/wifi_unstable.ex
+++ b/examples/wifi_demo/lib/wifi_demo/wifi_unstable.ex
@@ -2,7 +2,7 @@ defmodule WiFiDemo.WiFiUnstable do
   @moduledoc """
   Alarm for when WiFi bounces too frequently
   """
-  use Alarmist.Definition
+  use Alarmist.Alarm
 
   # WiFi must be down for at least 15 seconds or flapped 3 times in 60 seconds
   defalarm do

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -10,7 +10,7 @@ defmodule Alarmist do
   what alarms are currently active and subscribe to alarm status changes.
 
   It also provides a DSL for defining alarms based on other alarms. See
-  `Alarmist.Definition`.
+  `Alarmist.Alarm`.
   """
   alias Alarmist.Compiler
   alias Alarmist.Handler

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -140,7 +140,7 @@ defmodule Alarmist do
   end
 
   @doc """
-  Add a rule-based alarm
+  Add a managed alarm
 
   After this call, Alarmist will watch for alarms to be set based on the
   supplied rules and set or clear the specified alarm ID. The alarm ID
@@ -150,25 +150,25 @@ defmodule Alarmist do
   the previous alarm being replaced. Alarm subscribers won't receive
   redundant events if the rules are the same.
   """
-  @spec add_synthetic_alarm(alarm_id()) :: :ok
-  def add_synthetic_alarm(alarm_id) when is_atom(alarm_id) do
+  @spec add_managed_alarm(alarm_id()) :: :ok
+  def add_managed_alarm(alarm_id) when is_atom(alarm_id) do
     compiled_rules = alarm_id.__get_alarm__()
-    Handler.add_synthetic_alarm(alarm_id, compiled_rules)
+    Handler.add_managed_alarm(alarm_id, compiled_rules)
   end
 
   @doc """
-  Remove a rule-based alarm
+  Remove a managed alarm
   """
-  @spec remove_synthetic_alarm(alarm_id()) :: :ok
-  def remove_synthetic_alarm(alarm_id) when is_atom(alarm_id) do
-    Handler.remove_synthetic_alarm(alarm_id)
+  @spec remove_managed_alarm(alarm_id()) :: :ok
+  def remove_managed_alarm(alarm_id) when is_atom(alarm_id) do
+    Handler.remove_managed_alarm(alarm_id)
   end
 
   @doc """
-  Return all synthetic alarm IDs
+  Return all managed alarm IDs
   """
-  @spec synthetic_alarm_ids() :: [alarm_id()]
-  def synthetic_alarm_ids() do
-    Handler.synthetic_alarm_ids()
+  @spec managed_alarm_ids() :: [alarm_id()]
+  def managed_alarm_ids() do
+    Handler.managed_alarm_ids()
   end
 end

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-defmodule Alarmist.Definition do
+defmodule Alarmist.Alarm do
   @moduledoc """
   DSL for defining alarms
 
@@ -10,7 +10,7 @@ defmodule Alarmist.Definition do
 
   ```elixir
   defmodule MyAlarmModule do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       AlarmId1 and AlarmId2

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -12,13 +12,13 @@ defmodule Alarmist.Alarm do
   defmodule MyAlarmModule do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       AlarmId1 and AlarmId2
     end
   end
   ```
 
-  See `Alarmist.Ops` for what operations can be included in `defalarm` block.
+  See `Alarmist.Ops` for what operations can be included in `alarm_if` block.
   """
 
   defp expand_expression(expr, caller) do
@@ -96,7 +96,7 @@ defmodule Alarmist.Alarm do
     end
   end
 
-  defmacro defalarm(do: block) do
+  defmacro alarm_if(do: block) do
     expr_expanded = expand_expression(block, __CALLER__)
 
     quote do
@@ -107,25 +107,25 @@ defmodule Alarmist.Alarm do
           description: "Cannot define multiple alarms in a single module!"
       end
 
-      @alarmist_alarm_def unquote(Macro.to_string(block))
+      @alarmist_alarm_if unquote(Macro.to_string(block))
       @alarmist_alarm Alarmist.Compiler.compile(__MODULE__, unquote(expr_expanded))
     end
   end
 
   defmacro __before_compile__(env) do
     alarm = Module.get_attribute(env.module, :alarmist_alarm)
-    alarm_def = Module.get_attribute(env.module, :alarmist_alarm_def)
+    alarm_if = Module.get_attribute(env.module, :alarmist_alarm_if)
 
     if !alarm do
       raise CompileError,
         file: env.file,
         line: env.line,
-        description: "One defalarm expected, but not found."
+        description: "One alarm_if expected, but not found."
     end
 
     quote do
-      def __get_alarm_def__() do
-        unquote(alarm_def)
+      def __get_alarm_if__() do
+        unquote(alarm_if)
       end
 
       def __get_alarm__() do

--- a/lib/alarmist/compiler.ex
+++ b/lib/alarmist/compiler.ex
@@ -4,7 +4,7 @@
 #
 defmodule Alarmist.Compiler do
   @moduledoc """
-  Compiles synthetic alarm definitions into a list of rules
+  Compiles managed alarm definitions into a list of rules
   """
 
   @typedoc false

--- a/lib/alarmist/ops.ex
+++ b/lib/alarmist/ops.ex
@@ -20,7 +20,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       OriginalAlarm
@@ -44,7 +44,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       not OriginalAlarm
@@ -73,7 +73,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       Alarm1 and Alarm2
@@ -114,7 +114,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       Alarm1 or Alarm2
@@ -165,7 +165,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       debounce(Alarm1, 1_000)
@@ -206,7 +206,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       hold(Alarm1, 1_000)
@@ -250,7 +250,7 @@ defmodule Alarmist.Ops do
 
   ```elixir
   defmodule NewAlarm do
-    use Alarmist.Definition
+    use Alarmist.Alarm
 
     defalarm do
       intensity(Alarm1, 3, 60_000)

--- a/lib/alarmist/ops.ex
+++ b/lib/alarmist/ops.ex
@@ -22,7 +22,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       OriginalAlarm
     end
   end
@@ -46,7 +46,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       not OriginalAlarm
     end
   end
@@ -75,7 +75,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       Alarm1 and Alarm2
     end
   end
@@ -116,7 +116,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       Alarm1 or Alarm2
     end
   end
@@ -167,7 +167,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       debounce(Alarm1, 1_000)
     end
   end
@@ -208,7 +208,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       hold(Alarm1, 1_000)
     end
   end
@@ -252,7 +252,7 @@ defmodule Alarmist.Ops do
   defmodule NewAlarm do
     use Alarmist.Alarm
 
-    defalarm do
+    alarm_if do
       intensity(Alarm1, 3, 60_000)
     end
   end

--- a/test/alarmist/alarm_if_test.exs
+++ b/test/alarmist/alarm_if_test.exs
@@ -2,70 +2,70 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-defmodule Alarmist.DefAlarmTest do
+defmodule Alarmist.AlarmIfTest do
   use ExUnit.Case, async: true
 
   test "identity" do
     defmodule IdentityTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         MyAlarmId
       end
     end
 
     expected_result = [{Alarmist.Ops, :copy, [IdentityTest, MyAlarmId]}]
     assert IdentityTest.__get_alarm__() == expected_result
-    assert IdentityTest.__get_alarm_def__() == "MyAlarmId"
+    assert IdentityTest.__get_alarm_if__() == "MyAlarmId"
   end
 
   test "and" do
     defmodule AndTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId1 and AlarmId2
       end
     end
 
     expected_result = [{Alarmist.Ops, :logical_and, [AndTest, AlarmId1, AlarmId2]}]
     assert AndTest.__get_alarm__() == expected_result
-    assert AndTest.__get_alarm_def__() == "AlarmId1 and AlarmId2"
+    assert AndTest.__get_alarm_if__() == "AlarmId1 and AlarmId2"
   end
 
   test "not" do
     defmodule NotTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         not AlarmId1
       end
     end
 
     expected_result = [{Alarmist.Ops, :logical_not, [NotTest, AlarmId1]}]
     assert NotTest.__get_alarm__() == expected_result
-    assert NotTest.__get_alarm_def__() == "not AlarmId1"
+    assert NotTest.__get_alarm_if__() == "not AlarmId1"
   end
 
   test "debounce" do
     defmodule DebounceTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         debounce(AlarmId1, 1000)
       end
     end
 
     expected_result = [{Alarmist.Ops, :debounce, [DebounceTest, AlarmId1, 1000]}]
     assert DebounceTest.__get_alarm__() == expected_result
-    assert DebounceTest.__get_alarm_def__() == "debounce(AlarmId1, 1000)"
+    assert DebounceTest.__get_alarm_if__() == "debounce(AlarmId1, 1000)"
   end
 
   test "hold" do
     defmodule HoldTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         hold(AlarmId1, 2000)
       end
     end
@@ -78,7 +78,7 @@ defmodule Alarmist.DefAlarmTest do
     defmodule IntensityTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         intensity(AlarmId1, 5, 10000)
       end
     end
@@ -91,27 +91,27 @@ defmodule Alarmist.DefAlarmTest do
     defmodule AndOrTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId1 or (AlarmId2 and AlarmId3)
       end
     end
 
     expected_result = [
       {Alarmist.Ops, :logical_or,
-       [AndOrTest, AlarmId1, :"Elixir.Alarmist.DefAlarmTest.AndOrTest.0"]},
+       [AndOrTest, AlarmId1, :"Elixir.Alarmist.AlarmIfTest.AndOrTest.0"]},
       {Alarmist.Ops, :logical_and,
-       [:"Elixir.Alarmist.DefAlarmTest.AndOrTest.0", AlarmId2, AlarmId3]}
+       [:"Elixir.Alarmist.AlarmIfTest.AndOrTest.0", AlarmId2, AlarmId3]}
     ]
 
     assert AndOrTest.__get_alarm__() == expected_result
-    assert AndOrTest.__get_alarm_def__() == "AlarmId1 or (AlarmId2 and AlarmId3)"
+    assert AndOrTest.__get_alarm_if__() == "AlarmId1 or (AlarmId2 and AlarmId3)"
   end
 
   test "compound with not" do
     defmodule CompoundWithNotTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         (Id1 and Id2) or not (Id2 and Id3)
       end
     end
@@ -120,63 +120,63 @@ defmodule Alarmist.DefAlarmTest do
       {Alarmist.Ops, :logical_or,
        [
          CompoundWithNotTest,
-         :"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.0",
-         :"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.2"
+         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.0",
+         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.2"
        ]},
       {Alarmist.Ops, :logical_not,
        [
-         :"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.2",
-         :"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.1"
+         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.2",
+         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.1"
        ]},
       {Alarmist.Ops, :logical_and,
-       [:"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.1", Id2, Id3]},
+       [:"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.1", Id2, Id3]},
       {Alarmist.Ops, :logical_and,
-       [:"Elixir.Alarmist.DefAlarmTest.CompoundWithNotTest.0", Id1, Id2]}
+       [:"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.0", Id1, Id2]}
     ]
 
     assert CompoundWithNotTest.__get_alarm__() == expected_result
   end
 
-  test "complex defalarm with module attribute" do
+  test "complex alarm_if with module attribute" do
     defmodule ModAttrTest do
       use Alarmist.Alarm
 
       @debounce_value 1_000
 
-      defalarm do
+      alarm_if do
         timeout_value = @debounce_value + 100
         debounce(AlarmID1, timeout_value)
       end
     end
 
     expected_result = [
-      {Alarmist.Ops, :debounce, [Alarmist.DefAlarmTest.ModAttrTest, AlarmID1, 1100]}
+      {Alarmist.Ops, :debounce, [Alarmist.AlarmIfTest.ModAttrTest, AlarmID1, 1100]}
     ]
 
     assert ModAttrTest.__get_alarm__() == expected_result
   end
 
-  test "not specifying defalarm" do
+  test "not specifying alarm_if" do
     code = """
     defmodule NotSpecifiedTest do
       use Alarmist.Alarm
     end
     """
 
-    assert_raise CompileError, "nofile:1: One defalarm expected, but not found.", fn ->
+    assert_raise CompileError, "nofile:1: One alarm_if expected, but not found.", fn ->
       Code.eval_string(code)
     end
   end
 
-  test "specifying defalarm more than once" do
+  test "specifying alarm_if more than once" do
     code = """
     defmodule DoubleTest do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmID1
       end
-      defalarm do
+      alarm_if do
         AlarmID2
       end
     end

--- a/test/alarmist/defalarm_test.exs
+++ b/test/alarmist/defalarm_test.exs
@@ -7,7 +7,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "identity" do
     defmodule IdentityTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         MyAlarmId
@@ -21,7 +21,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "and" do
     defmodule AndTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmId1 and AlarmId2
@@ -35,7 +35,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "not" do
     defmodule NotTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         not AlarmId1
@@ -49,7 +49,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "debounce" do
     defmodule DebounceTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         debounce(AlarmId1, 1000)
@@ -63,7 +63,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "hold" do
     defmodule HoldTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         hold(AlarmId1, 2000)
@@ -76,7 +76,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "intensity" do
     defmodule IntensityTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         intensity(AlarmId1, 5, 10000)
@@ -89,7 +89,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "and and or" do
     defmodule AndOrTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmId1 or (AlarmId2 and AlarmId3)
@@ -109,7 +109,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "compound with not" do
     defmodule CompoundWithNotTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         (Id1 and Id2) or not (Id2 and Id3)
@@ -139,7 +139,7 @@ defmodule Alarmist.DefAlarmTest do
 
   test "complex defalarm with module attribute" do
     defmodule ModAttrTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       @debounce_value 1_000
 
@@ -159,7 +159,7 @@ defmodule Alarmist.DefAlarmTest do
   test "not specifying defalarm" do
     code = """
     defmodule NotSpecifiedTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
     end
     """
 
@@ -171,7 +171,7 @@ defmodule Alarmist.DefAlarmTest do
   test "specifying defalarm more than once" do
     code = """
     defmodule DoubleTest do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmID1

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -138,9 +138,9 @@ defmodule AlarmistTest do
 
   test "adding an alarm many times" do
     defmodule MultiAddAlarm do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId1 or AlarmId2 or AlarmId3
       end
     end
@@ -176,7 +176,7 @@ defmodule AlarmistTest do
     defmodule TestAlarm do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId1 and AlarmId2
       end
     end
@@ -213,7 +213,7 @@ defmodule AlarmistTest do
     defmodule MyAlarm6 do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId10
       end
     end
@@ -237,7 +237,7 @@ defmodule AlarmistTest do
     defmodule MyAlarm7 do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         AlarmId10
       end
     end
@@ -266,7 +266,7 @@ defmodule AlarmistTest do
     defmodule HoldAlarm do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         # Hold TestAlarm on for 250 ms after AlarmID1 goes away
         hold(AlarmId1, 250)
       end
@@ -316,7 +316,7 @@ defmodule AlarmistTest do
     defmodule IntensityAlarm do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         intensity(AlarmId1, 3, 250)
       end
     end
@@ -356,7 +356,7 @@ defmodule AlarmistTest do
       defmodule DebounceAlarm do
         use Alarmist.Alarm
 
-        defalarm do
+        alarm_if do
           debounce(AlarmId2, 100)
         end
       end
@@ -420,7 +420,7 @@ defmodule AlarmistTest do
       defmodule DebounceAlarm2 do
         use Alarmist.Alarm
 
-        defalarm do
+        alarm_if do
           debounce(AlarmId2a, 100)
         end
       end
@@ -449,7 +449,7 @@ defmodule AlarmistTest do
       defmodule DebounceAlarm3 do
         use Alarmist.Alarm
 
-        defalarm do
+        alarm_if do
           debounce(AlarmId2b, 100)
         end
       end
@@ -472,7 +472,7 @@ defmodule AlarmistTest do
     defmodule TestAlarm2 do
       use Alarmist.Alarm
 
-      defalarm do
+      alarm_if do
         (Id1 and Id2) or not (Id2 and Id3)
       end
     end

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -174,7 +174,7 @@ defmodule AlarmistTest do
 
   test "basic usage" do
     defmodule TestAlarm do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmId1 and AlarmId2
@@ -211,7 +211,7 @@ defmodule AlarmistTest do
 
   test "trigger on register" do
     defmodule MyAlarm6 do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmId10
@@ -235,7 +235,7 @@ defmodule AlarmistTest do
 
   test "cleared when rule deleted" do
     defmodule MyAlarm7 do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         AlarmId10
@@ -264,7 +264,7 @@ defmodule AlarmistTest do
 
   test "hold rules" do
     defmodule HoldAlarm do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         # Hold TestAlarm on for 250 ms after AlarmID1 goes away
@@ -314,7 +314,7 @@ defmodule AlarmistTest do
 
   test "intensity rules" do
     defmodule IntensityAlarm do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         intensity(AlarmId1, 3, 250)
@@ -354,7 +354,7 @@ defmodule AlarmistTest do
   describe "debounce tests" do
     test "debounce rules" do
       defmodule DebounceAlarm do
-        use Alarmist.Definition
+        use Alarmist.Alarm
 
         defalarm do
           debounce(AlarmId2, 100)
@@ -418,7 +418,7 @@ defmodule AlarmistTest do
 
     test "debounce transient set-clear-set" do
       defmodule DebounceAlarm2 do
-        use Alarmist.Definition
+        use Alarmist.Alarm
 
         defalarm do
           debounce(AlarmId2a, 100)
@@ -447,7 +447,7 @@ defmodule AlarmistTest do
 
     test "debounce transient clear-set-clear" do
       defmodule DebounceAlarm3 do
-        use Alarmist.Definition
+        use Alarmist.Alarm
 
         defalarm do
           debounce(AlarmId2b, 100)
@@ -470,7 +470,7 @@ defmodule AlarmistTest do
 
   test "compound rules" do
     defmodule TestAlarm2 do
-      use Alarmist.Definition
+      use Alarmist.Alarm
 
       defalarm do
         (Id1 and Id2) or not (Id2 and Id3)


### PR DESCRIPTION
See https://github.com/smartrent/alarmist/issues/39 for the reasoning behind most of the renames. The introduction of the alarm types concept is coming in the PR with parameterized alarms.

This PR doesn't have any logic changes.