### PR TITLE
Add alarm severities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ tags: &tags
   [
     1.18.3-erlang-27.3.3-alpine-3.21.3,
     1.17.3-erlang-27.3.3-alpine-3.21.3,
-    1.16.3-erlang-26.2.5.11-alpine-3.21.3,
-    1.15.8-erlang-26.2.5.11-alpine-3.21.3
+    1.16.3-erlang-26.2.5.11-alpine-3.21.3
   ]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,38 @@ end
 In this example, `Alarmist` will set `MyNewAlarm` only when both
 `InterestingAlarm1` and `InterestingAlarm2` are set.
 
-The following sections describe the operators available for managed alarms.
+## Alarm options
+
+Alarmist provides the following options for managed alarms:
+
+* `:level` - the severity of the alarm
+
+### Alarm severity
+
+Alarmist supports labeling managed alarms with severity levels matching those
+in `t:Logger.level/0`. Alarms default to the `:warning` level and intermediate
+alarms created internally by Alarmist default to `:debug`.
+
+The following example shows how to set an alarm's severity.
+
+```elixir
+defmodule MyNewAlarm do
+  use Alarmist.Alarm, level: :info
+
+  alarm_if do
+    ...
+  end
+end
+```
+
+Alarmist includes the severity in alarm status change events and also lets you
+filter active alarms with `Alarmist.get_alarms/1` and
+`Alarmist.get_alarm_ids/1`.
+
+## Managed alarm operators
+
+Managed alarms defined with `alarm_if` support boolean operators and a few
+special purpose operators. The following sections document each of these.
 
 ### Identity
 

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -18,6 +18,10 @@ defmodule Alarmist.Alarm do
   end
   ```
 
+  The following options can be passed to `use Alarmist.Alarm`:
+
+  * `:level` - the alarm severity. See `t:Logger.level/0`. Defaults to `:warning`.
+
   See `Alarmist.Ops` for what operations can be included in `alarm_if` block.
   """
 
@@ -88,11 +92,27 @@ defmodule Alarmist.Alarm do
     end
   end
 
-  defmacro __using__(_options) do
+  defmacro __using__(options) do
+    level = Keyword.get(options, :level, :warning)
+
+    if level not in Logger.levels() do
+      raise ArgumentError,
+            "Invalid level #{inspect(level)}. Must be one of #{inspect(Logger.levels())}"
+    end
+
     quote do
       @before_compile unquote(__MODULE__)
+      @alarmist_level unquote(level)
+
       Module.register_attribute(__MODULE__, :alarmist_alarm, [])
+
       import unquote(__MODULE__)
+
+      @doc false
+      @spec __alarm_level__() :: Logger.level()
+      def __alarm_level__() do
+        @alarmist_level
+      end
     end
   end
 

--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -9,18 +9,20 @@ defmodule Alarmist.Event do
   * `:id` - which alarm
   * `:state` - `:set` or `:clear`
   * `:description` - alarm description or `nil` when the alarm has been cleared
+  * `:level` - alarm severity if known to Alarmist. Defaults to `:warning`
   * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
   * `:previous_state` - the previous value (`:unknown` if no previous information)
   * `:previous_timestamp` - the timestamp when the property changed to
     `:previous_state`. Use this to calculate how long the property was the
     previous state.
   """
-  defstruct [:id, :state, :description, :timestamp, :previous_state, :previous_timestamp]
+  defstruct [:id, :state, :description, :level, :timestamp, :previous_state, :previous_timestamp]
 
   @type t() :: %__MODULE__{
           id: Alarmist.alarm_id(),
           state: Alarmist.alarm_state(),
           description: Alarmist.alarm_description(),
+          level: Logger.level(),
           previous_state: Alarmist.alarm_state() | :unknown,
           timestamp: integer(),
           previous_timestamp: integer()
@@ -29,19 +31,20 @@ defmodule Alarmist.Event do
   @doc false
   @spec from_property_table(PropertyTable.Event.t()) :: t()
   def from_property_table(%PropertyTable.Event{property: [alarm_id]} = event) do
-    {state, description} = property_to_info(event.value)
-    {previous_state, _} = property_to_info(event.previous_value)
+    {state, description, level} = property_to_info(event.value)
+    {previous_state, _, _} = property_to_info(event.previous_value)
 
     %__MODULE__{
       id: alarm_id,
       state: state,
       description: description,
+      level: level,
       timestamp: event.timestamp,
       previous_state: previous_state,
       previous_timestamp: event.previous_timestamp
     }
   end
 
-  defp property_to_info({state, description}), do: {state, description}
-  defp property_to_info(nil), do: {:unknown, nil}
+  defp property_to_info({state, description, level}), do: {state, description, level}
+  defp property_to_info(nil), do: {:unknown, nil, :warning}
 end

--- a/lib/alarmist/handler.ex
+++ b/lib/alarmist/handler.ex
@@ -68,7 +68,8 @@ defmodule Alarmist.Handler do
   end
 
   defp lookup(alarm_id) do
-    PropertyTable.get(Alarmist, [alarm_id], {:clear, nil})
+    {op, description, _level} = PropertyTable.get(Alarmist, [alarm_id], {:clear, nil, :debug})
+    {op, description}
   end
 
   @doc """
@@ -148,12 +149,12 @@ defmodule Alarmist.Handler do
   #   # of an inconsistent view of the table.
   # end
 
-  defp run_side_effect({:set, alarm_id, description}) do
-    PropertyTable.put(Alarmist, [alarm_id], {:set, description})
+  defp run_side_effect({:set, alarm_id, description, level}) do
+    PropertyTable.put(Alarmist, [alarm_id], {:set, description, level})
   end
 
-  defp run_side_effect({:clear, alarm_id, _}) do
-    PropertyTable.put(Alarmist, [alarm_id], {:clear, nil})
+  defp run_side_effect({:clear, alarm_id, _, level}) do
+    PropertyTable.put(Alarmist, [alarm_id], {:clear, nil, level})
   end
 
   defp run_side_effect({:start_timer, alarm_id, timeout, what, params}) do

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Alarmist.MixProject do
     [
       app: :alarmist,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: @description,
       package: package(),

--- a/test/alarmist/engine_test.exs
+++ b/test/alarmist/engine_test.exs
@@ -17,8 +17,8 @@ defmodule Alarmist.EngineTest do
       {_engine, side_effects} = Engine.commit_side_effects(engine)
 
       assert side_effects == [
-               {:set, :my_alarm_id, "description"},
-               {:set, :my_alarm_id2, "description2"}
+               {:set, :my_alarm_id, "description", :warning},
+               {:set, :my_alarm_id2, "description2", :warning}
              ]
     end
 
@@ -44,7 +44,7 @@ defmodule Alarmist.EngineTest do
       {_engine, side_effects} = Engine.commit_side_effects(engine)
 
       # transient alarm doesn't propagate
-      assert side_effects == [{:clear, :my_alarm_id, nil}]
+      assert side_effects == [{:clear, :my_alarm_id, nil, :warning}]
     end
 
     test "redundant set alarms" do
@@ -57,7 +57,7 @@ defmodule Alarmist.EngineTest do
       {_engine, side_effects} = Engine.commit_side_effects(engine)
 
       # only run final set
-      assert side_effects == [{:set, :my_alarm_id, "description2"}]
+      assert side_effects == [{:set, :my_alarm_id, "description2", :warning}]
     end
   end
 

--- a/test/integration/boolean_test.exs
+++ b/test/integration/boolean_test.exs
@@ -49,29 +49,20 @@ defmodule Integration.BooleanTest do
   end
 
   test "not not" do
-    # This is a simple way of exercising an intermediate alarm that defaults to set
-    defmodule NotNotAlarm do
-      use Alarmist.Alarm
-
-      alarm_if do
-        not not AlarmId1
-      end
-    end
-
     Alarmist.subscribe(NotNotAlarm)
     refute_received _
 
     Alarmist.add_managed_alarm(NotNotAlarm)
     refute_received _
 
-    :alarm_handler.set_alarm({AlarmId1, nil})
+    :alarm_handler.set_alarm({NotNotTriggerAlarm, nil})
 
     assert_receive %Alarmist.Event{
       id: NotNotAlarm,
       state: :set
     }
 
-    :alarm_handler.clear_alarm(AlarmId1)
+    :alarm_handler.clear_alarm(NotNotTriggerAlarm)
 
     assert_receive %Alarmist.Event{
       id: NotNotAlarm,

--- a/test/support/alarm_utililities.ex
+++ b/test/support/alarm_utililities.ex
@@ -18,7 +18,7 @@ defmodule AlarmUtilities do
   @spec assert_clean_state() :: :ok
   def assert_clean_state() do
     assert Alarmist.managed_alarm_ids() == []
-    assert Alarmist.get_alarms() == []
+    assert Alarmist.get_alarms(level: :debug) == []
 
     refute_receive %Alarmist.Event{}
 

--- a/test/support/not_not_alarm.ex
+++ b/test/support/not_not_alarm.ex
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NotNotAlarm do
+  use Alarmist.Alarm
+
+  # This is a simple way of exercising an intermediate alarm that defaults to set
+  alarm_if do
+    not not NotNotTriggerAlarm
+  end
+end

--- a/test/support/severity_alarms.ex
+++ b/test/support/severity_alarms.ex
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2023 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule ErrorAlarm do
+  use Alarmist.Alarm, level: :error
+
+  alarm_if do
+    RootSeverityAlarm
+  end
+end
+
+defmodule WarningAlarm do
+  use Alarmist.Alarm, level: :warning
+
+  alarm_if do
+    RootSeverityAlarm
+  end
+end
+
+defmodule InfoAlarm do
+  use Alarmist.Alarm, level: :info
+
+  alarm_if do
+    RootSeverityAlarm
+  end
+end
+
+defmodule DebugAlarm do
+  use Alarmist.Alarm, level: :debug
+
+  alarm_if do
+    RootSeverityAlarm
+  end
+end


### PR DESCRIPTION
This makes it possible to filter and sort through active alarms and also
to more easily ignore all of the temporary ones. Alarms severities
are the same values as Logger levels. The default is `:warning`.

This drops support for Elixir 1.15 to avoid handling the differences
with the pre-1.16 Logger.

This addresses #22 by making internal alarm IDs have `:debug` severity
and then making the default when getting alarms be to only include
`:info` and higher.
