### PR TITLE
Add parameterized alarm support

### DIFF
--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -30,7 +30,7 @@ defmodule Alarmist.Event do
 
   @doc false
   @spec from_property_table(PropertyTable.Event.t()) :: t()
-  def from_property_table(%PropertyTable.Event{property: [alarm_id]} = event) do
+  def from_property_table(%PropertyTable.Event{property: alarm_id} = event) do
     {state, description, level} = property_to_info(event.value)
     {previous_state, _, _} = property_to_info(event.previous_value)
 

--- a/lib/alarmist/matcher.ex
+++ b/lib/alarmist/matcher.ex
@@ -9,6 +9,8 @@ defmodule Alarmist.Matcher do
 
   @behaviour PropertyTable.Matcher
 
+  import Alarmist, only: [is_alarm_id: 1]
+
   @doc """
   Check whether a property is valid
 
@@ -16,18 +18,10 @@ defmodule Alarmist.Matcher do
   information about the issue.
   """
   @impl PropertyTable.Matcher
-  def check_property([]), do: :ok
+  def check_property(alarm_id) when is_alarm_id(alarm_id), do: :ok
 
-  def check_property([part | rest]) when is_atom(part) do
-    check_property(rest)
-  end
-
-  def check_property([part | _]) do
-    {:error, ArgumentError.exception("Invalid property element '#{inspect(part)}'")}
-  end
-
-  def check_property(_other) do
-    {:error, ArgumentError.exception("Pattern should be a list of atoms")}
+  def check_property(other) do
+    {:error, ArgumentError.exception("Invalid property element '#{inspect(other)}'")}
   end
 
   @doc """
@@ -37,33 +31,44 @@ defmodule Alarmist.Matcher do
   information about the issue.
   """
   @impl PropertyTable.Matcher
-  def check_pattern([]), do: :ok
+  def check_pattern(alarm_type) when is_atom(alarm_type), do: :ok
+  def check_pattern({alarm_type, _}) when is_atom(alarm_type), do: :ok
+  def check_pattern({alarm_type, _, _}) when is_atom(alarm_type), do: :ok
+  def check_pattern({alarm_type, _, _, _}) when is_atom(alarm_type), do: :ok
 
-  def check_pattern([part | rest]) when is_atom(part) or part in [:_, :"$"] do
-    check_pattern(rest)
-  end
-
-  def check_pattern([part | _]) do
-    {:error, ArgumentError.exception("Invalid pattern element '#{inspect(part)}'")}
-  end
-
-  def check_pattern(_other) do
-    {:error, ArgumentError.exception("Pattern should be a list of atoms or wildcard atoms")}
+  def check_pattern(other) do
+    {:error, ArgumentError.exception("Invalid pattern element '#{inspect(other)}'")}
   end
 
   @doc """
   Returns true if the pattern matches the specified property
   """
   @impl PropertyTable.Matcher
-  def matches?([value | match_rest], [value | property_rest]) do
-    __MODULE__.matches?(match_rest, property_rest)
+
+  # Exact match
+  def matches?(alarm_id, alarm_id), do: true
+
+  # Match everything
+  def matches?(:_, _alarm_id), do: true
+
+  # Handle the really common 2-tuple case for efficiency
+  def matches?({alarm_type, :_}, {alarm_type, _p}), do: true
+  def matches?({:_, p}, {_alarm_type, p}), do: true
+  def matches?({:_, :_}, {_alarm_type, _p}), do: true
+
+  # Generically handle the other tuple cases
+  def matches?(pattern, actual) when tuple_size(pattern) == tuple_size(actual) do
+    pattern_list = Tuple.to_list(pattern)
+    actual_list = Tuple.to_list(actual)
+
+    all_elements_match?(pattern_list, actual_list)
   end
 
-  def matches?([:_ | match_rest], [_any | property_rest]) do
-    __MODULE__.matches?(match_rest, property_rest)
-  end
-
-  def matches?([], _property), do: true
-  def matches?([:"$"], []), do: true
+  # The rest
   def matches?(_pattern, _property), do: false
+
+  defp all_elements_match?([], []), do: true
+  defp all_elements_match?([:_ | pattern], [_ | actual]), do: all_elements_match?(pattern, actual)
+  defp all_elements_match?([p | pattern], [p | actual]), do: all_elements_match?(pattern, actual)
+  defp all_elements_match?(_, _), do: false
 end

--- a/test/alarmist/alarm_if_test.exs
+++ b/test/alarmist/alarm_if_test.exs
@@ -16,7 +16,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :copy, [IdentityTest, MyAlarmId]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert IdentityTest.__get_condition__() == expected_result
@@ -34,7 +35,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :logical_and, [AndTest, AlarmId1, AlarmId2]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert AndTest.__get_condition__() == expected_result
@@ -52,7 +54,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :logical_not, [NotTest, AlarmId1]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert NotTest.__get_condition__() == expected_result
@@ -70,7 +73,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :debounce, [DebounceTest, AlarmId1, 1000]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert DebounceTest.__get_condition__() == expected_result
@@ -88,7 +92,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :hold, [HoldTest, AlarmId1, 2000]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert HoldTest.__get_condition__() == expected_result
@@ -105,7 +110,8 @@ defmodule Alarmist.AlarmIfTest do
 
     expected_result = %{
       rules: [{Alarmist.Ops, :intensity, [IntensityTest, AlarmId1, 5, 10000]}],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert IntensityTest.__get_condition__() == expected_result
@@ -127,7 +133,8 @@ defmodule Alarmist.AlarmIfTest do
         {Alarmist.Ops, :logical_and,
          [:"Elixir.Alarmist.AlarmIfTest.AndOrTest.0", AlarmId2, AlarmId3]}
       ],
-      temporaries: [:"Elixir.Alarmist.AlarmIfTest.AndOrTest.0"]
+      temporaries: [:"Elixir.Alarmist.AlarmIfTest.AndOrTest.0"],
+      options: %{style: :atom, parameters: []}
     }
 
     assert AndOrTest.__get_condition__() == expected_result
@@ -165,7 +172,8 @@ defmodule Alarmist.AlarmIfTest do
         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.2",
         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.1",
         :"Elixir.Alarmist.AlarmIfTest.CompoundWithNotTest.0"
-      ]
+      ],
+      options: %{style: :atom, parameters: []}
     }
 
     assert CompoundWithNotTest.__get_condition__() == expected_result
@@ -187,7 +195,8 @@ defmodule Alarmist.AlarmIfTest do
       rules: [
         {Alarmist.Ops, :debounce, [Alarmist.AlarmIfTest.ModAttrTest, AlarmID1, 1100]}
       ],
-      temporaries: []
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
     }
 
     assert ModAttrTest.__get_condition__() == expected_result

--- a/test/alarmist/compiler_test.exs
+++ b/test/alarmist/compiler_test.exs
@@ -13,10 +13,12 @@ defmodule Alarmist.CompilerTest do
 
       result = %{
         rules: [{Alarmist.Ops, :copy, [:result_alarm_id, :my_alarm_id]}],
-        temporaries: []
+        temporaries: [],
+        options: %{style: :atom, parameters: []}
       }
 
-      assert Compiler.compile(:result_alarm_id, program) == result
+      assert Compiler.compile(:result_alarm_id, program, %{style: :atom, parameters: []}) ==
+               result
     end
 
     test "and" do
@@ -24,10 +26,12 @@ defmodule Alarmist.CompilerTest do
 
       result = %{
         rules: [{Alarmist.Ops, :logical_and, [:result_alarm_id, :alarm_id1, :alarm_id2]}],
-        temporaries: []
+        temporaries: [],
+        options: %{style: :atom, parameters: []}
       }
 
-      assert Compiler.compile(:result_alarm_id, program) == result
+      assert Compiler.compile(:result_alarm_id, program, %{style: :atom, parameters: []}) ==
+               result
     end
 
     test "and and or" do
@@ -38,10 +42,12 @@ defmodule Alarmist.CompilerTest do
           {Alarmist.Ops, :logical_and, [:result_alarm_id, :alarm_id1, :"result_alarm_id.0"]},
           {Alarmist.Ops, :logical_or, [:"result_alarm_id.0", :alarm_id2, :alarm_id3]}
         ],
-        temporaries: [:"result_alarm_id.0"]
+        temporaries: [:"result_alarm_id.0"],
+        options: %{style: :atom, parameters: []}
       }
 
-      assert Compiler.compile(:result_alarm_id, program) == result
+      assert Compiler.compile(:result_alarm_id, program, %{style: :atom, parameters: []}) ==
+               result
     end
   end
 end

--- a/test/alarmist/matcher_test.exs
+++ b/test/alarmist/matcher_test.exs
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.MatcherTest do
+  use ExUnit.Case, async: true
+  alias Alarmist.Matcher
+
+  describe "match/2" do
+    test "exact matches" do
+      assert Matcher.matches?(:alarm, :alarm)
+      assert Matcher.matches?({:alarm, 1}, {:alarm, 1})
+      assert Matcher.matches?({:alarm, 1, 2}, {:alarm, 1, 2})
+
+      refute Matcher.matches?(:alarm, nil)
+      refute Matcher.matches?({:alarm, 1}, {:alarm, 3})
+      refute Matcher.matches?({:alarm, 1, 2}, {:alarm, 1, 3})
+    end
+
+    test "everything wild card" do
+      assert Matcher.matches?(:_, :alarm)
+      assert Matcher.matches?(:_, {:alarm, 1})
+      assert Matcher.matches?(:_, {:alarm, 1, 2})
+      assert Matcher.matches?(:_, {:alarm, 1, 2, 3})
+    end
+
+    test "2-tuple wild cards" do
+      assert Matcher.matches?({:alarm, :_}, {:alarm, 1})
+      refute Matcher.matches?({:alarm, :_}, {:another_alarm, 1})
+
+      assert Matcher.matches?({:_, 1}, {:alarm, 1})
+      assert Matcher.matches?({:_, 1}, {:another_alarm, 1})
+      refute Matcher.matches?({:_, 1}, {:alarm, 2})
+
+      # different tuple sizes
+      refute Matcher.matches?({:_, :_}, {:alarm})
+      refute Matcher.matches?({:_, :_}, {:alarm, 1, 2})
+      refute Matcher.matches?({:_, :_}, {:alarm, 1, 2, 3})
+    end
+
+    test "3-tuple wild cards" do
+      assert Matcher.matches?({:alarm, :_, :_}, {:alarm, 1, 2})
+      refute Matcher.matches?({:alarm, :_, :_}, {:another_alarm, 1, 2})
+
+      assert Matcher.matches?({:_, 1, :_}, {:alarm, 1, 2})
+      assert Matcher.matches?({:_, 1, :_}, {:another_alarm, 1, 2})
+      refute Matcher.matches?({:_, 1, :_}, {:alarm, 2, 2})
+
+      assert Matcher.matches?({:_, :_, 2}, {:alarm, 1, 2})
+      assert Matcher.matches?({:_, :_, 2}, {:another_alarm, 1, 2})
+      refute Matcher.matches?({:_, :_, 2}, {:alarm, 1, 3})
+
+      # different tuple sizes
+      refute Matcher.matches?({:_, :_, :_}, {:alarm})
+      refute Matcher.matches?({:_, :_, :_}, {:alarm, 1})
+      refute Matcher.matches?({:_, :_, :_}, {:alarm, 1, 2, 3})
+    end
+  end
+end

--- a/test/integration/parameterized_test.exs
+++ b/test/integration/parameterized_test.exs
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Integration.ParameterizedTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    on_exit(fn -> AlarmUtilities.assert_clean_state() end)
+  end
+
+  test "parameterized identity" do
+    Alarmist.subscribe({IdentityTuple1Alarm, :_})
+    Alarmist.add_managed_alarm({IdentityTuple1Alarm, "eth0"})
+    Alarmist.add_managed_alarm({IdentityTuple1Alarm, "wlan0"})
+    refute_received _
+
+    :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "eth0"}, nil})
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "eth0"}, state: :set}
+
+    :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "wlan0"}, nil})
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "wlan0"}, state: :set}
+
+    :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "eth0"})
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "eth0"}, state: :clear}
+
+    :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "wlan0"})
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "wlan0"}, state: :clear}
+
+    refute_receive _
+    Alarmist.remove_managed_alarm({IdentityTuple1Alarm, "eth0"})
+    Alarmist.remove_managed_alarm({IdentityTuple1Alarm, "wlan0"})
+  end
+
+  test "parameterized trigger alarm" do
+    defmodule WiredEthernetAlarm do
+      use Alarmist.Alarm
+
+      alarm_if do
+        {NetworkTriggerAlarm, "eth0"}
+      end
+    end
+
+    Alarmist.add_managed_alarm(WiredEthernetAlarm)
+    Alarmist.subscribe(WiredEthernetAlarm)
+    refute_received _
+
+    :alarm_handler.set_alarm({{NetworkTriggerAlarm, "eth0"}, nil})
+    assert_receive %Alarmist.Event{id: WiredEthernetAlarm, state: :set}
+
+    :alarm_handler.set_alarm({{NetworkTriggerAlarm, "wlan0"}, nil})
+    refute_received _
+
+    :alarm_handler.clear_alarm({NetworkTriggerAlarm, "eth0"})
+    assert_receive %Alarmist.Event{id: WiredEthernetAlarm, state: :clear}
+
+    :alarm_handler.clear_alarm({NetworkTriggerAlarm, "wlan0"})
+    refute_receive _
+
+    Alarmist.remove_managed_alarm(WiredEthernetAlarm)
+  end
+
+  test "parameterized subscription with temporaries" do
+    Alarmist.subscribe({CompoundTuple1Alarm, :_})
+    Alarmist.add_managed_alarm({CompoundTuple1Alarm, "eth0"})
+    Alarmist.add_managed_alarm({CompoundTuple1Alarm, "wlan0"})
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "eth0"}, state: :set}
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "wlan0"}, state: :set}
+
+    :alarm_handler.set_alarm({{CompoundTuple1Trigger2Alarm, "eth0"}, nil})
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "eth0"}, state: :clear}
+
+    :alarm_handler.set_alarm({{CompoundTuple1TriggerAlarm, "eth0"}, nil})
+    refute_receive _
+
+    :alarm_handler.set_alarm({GlobalTriggerAlarm, nil})
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "eth0"}, state: :set}
+
+    :alarm_handler.clear_alarm({CompoundTuple1TriggerAlarm, "eth0"})
+
+    Alarmist.remove_managed_alarm({CompoundTuple1Alarm, "eth0"})
+    Alarmist.remove_managed_alarm({CompoundTuple1Alarm, "wlan0"})
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "wlan0"}, state: :clear}
+    :alarm_handler.clear_alarm(GlobalTriggerAlarm)
+    :alarm_handler.clear_alarm({CompoundTuple1Trigger2Alarm, "eth0"})
+  end
+
+  test "two parameter identity" do
+    Alarmist.subscribe({IdentityTuple2Alarm, :_, :_})
+    Alarmist.add_managed_alarm({IdentityTuple2Alarm, "param1", "param2"})
+    refute_received _
+
+    :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "param1", "param2"}, nil})
+    assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :set}
+
+    :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "param1", "param2"})
+    assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :clear}
+
+    refute_receive _
+    Alarmist.remove_managed_alarm({IdentityTuple2Alarm, "param1", "param2"})
+  end
+
+  test "three parameter identity" do
+    Alarmist.subscribe({IdentityTuple3Alarm, :_, :_, :_})
+    Alarmist.add_managed_alarm({IdentityTuple3Alarm, "param1", "param2", "param3"})
+    refute_received _
+
+    :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "param1", "param2", "param3"}, nil})
+
+    assert_receive %Alarmist.Event{
+      id: {IdentityTuple3Alarm, "param1", "param2", "param3"},
+      state: :set
+    }
+
+    :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "param1", "param2", "param3"})
+
+    assert_receive %Alarmist.Event{
+      id: {IdentityTuple3Alarm, "param1", "param2", "param3"},
+      state: :clear
+    }
+
+    refute_receive _
+    Alarmist.remove_managed_alarm({IdentityTuple3Alarm, "param1", "param2", "param3"})
+  end
+end

--- a/test/support/compound_tuple1_alarm.ex
+++ b/test/support/compound_tuple1_alarm.ex
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule CompoundTuple1Alarm do
+  use Alarmist.Alarm, style: :tagged_tuple, parameters: [:parameter1]
+
+  alarm_if do
+    ({CompoundTuple1TriggerAlarm, parameter1} and GlobalTriggerAlarm) or
+      not {CompoundTuple1Trigger2Alarm, parameter1}
+  end
+end

--- a/test/support/identity_tuple_alarms.ex
+++ b/test/support/identity_tuple_alarms.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule IdentityTuple1Alarm do
+  use Alarmist.Alarm, style: :tagged_tuple, parameters: [:parameter1]
+
+  alarm_if do
+    {IdentityTupleTriggerAlarm, parameter1}
+  end
+end
+
+defmodule IdentityTuple2Alarm do
+  use Alarmist.Alarm, style: :tagged_tuple, parameters: [:parameter1, :parameter2]
+
+  alarm_if do
+    {IdentityTupleTriggerAlarm, parameter1, parameter2}
+  end
+end
+
+defmodule IdentityTuple3Alarm do
+  use Alarmist.Alarm, style: :tagged_tuple, parameters: [:parameter1, :parameter2, :parameter3]
+
+  alarm_if do
+    {IdentityTupleTriggerAlarm, parameter1, parameter2, parameter3}
+  end
+end


### PR DESCRIPTION
This adds the concept of alarm_type to differentiate references to
alarms that aren't fully specified. Currently only alarm_ids that are
tagged tuples like `{alarm_name, arg1, arg2 ...}` are supported.

A motivating use case is for separating network alarms based on network
interface. For example, you can now have a `NetworkBroken` alarm that
gets set and cleared as `{NetworkBroken, "eth0"}`.
