### PR TITLE
Fix issue that skips app environment alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ iex> flush
 }
 ```
 
+## Configuration via the application environment
+
+It's possible to define managed alarms to add when the Alarmist application
+starts. This has some convenience if you'd prefer to list all managed alarms in
+your `config.exs` rather than distribute their registration to runtime.
+
+```elixir
+config :alarmist,
+  managed_alarms: [FirstManagedAlarm, SecondManagedAlarm]
+```
+
+When Alarmist starts, it will force those modules to be loaded. Alarmist skips
+any alarm modules that have issues and just logs an error.
+
 ## License
 
 Alarmist is licensed under the Apache License, Version 2.0.

--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -214,6 +214,13 @@ defmodule Alarmist do
   """
   @spec add_managed_alarm(alarm_id()) :: :ok
   def add_managed_alarm(alarm_id) when is_alarm_id(alarm_id) do
+    condition = resolve_managed_alarm_condition(alarm_id)
+    Handler.add_managed_alarm(alarm_id, condition)
+  end
+
+  @doc false
+  @spec resolve_managed_alarm_condition(alarm_id()) :: compiled_condition()
+  def resolve_managed_alarm_condition(alarm_id) when is_alarm_id(alarm_id) do
     alarm_type = alarm_type(alarm_id)
 
     if not (Code.ensure_loaded(alarm_type) == {:module, alarm_type}) or
@@ -224,8 +231,7 @@ defmodule Alarmist do
 
     params = alarm_type.__alarm_parameters__(alarm_id)
 
-    condition = instantiate_alarm_conditions(alarm_type, params)
-    Handler.add_managed_alarm(alarm_id, condition)
+    instantiate_alarm_conditions(alarm_type, params)
   end
 
   defp instantiate_alarm_conditions(alarm_type, params) do


### PR DESCRIPTION
It turns out that managed alarms that were to be added via the app
environment never were actually added. This was an undocumented feature.
In addition to the fix, this adds unit tests and a short paragraph to
the readme.
