### PR TITLE
Fix startup race due to async handler initialization

### DIFF
--- a/lib/alarmist/application.ex
+++ b/lib/alarmist/application.ex
@@ -23,14 +23,47 @@ defmodule Alarmist.Application do
     Supervisor.start_link(children, opts)
   end
 
+  @impl Application
+  def stop(_state) do
+    :gen_event.delete_handler(:alarm_handler, Alarmist.Handler, :remove_handler)
+    :ok
+  end
+
   defp install_handler() do
     config = Application.get_all_env(:alarmist)
 
-    :ok =
-      :gen_event.swap_handler(
-        :alarm_handler,
-        {:alarm_handler, :swap},
-        {Alarmist.Handler, config}
-      )
+    # Since we don't know whether we're being installed for the first time or
+    # restarted or if something is just messed up, check the current handlers
+    # and pick the one to swap out. If there's somehow an `:alarm_handler` and
+    # an `Alarmist.Handler`, then delete the other one. This case has not been
+    # seen in practice.
+    {to_swap, others} = :gen_event.which_handlers(:alarm_handler) |> pick_handler([])
+    gc_handlers(others)
+
+    maybe_swap_alarm_handler(to_swap, config)
+  end
+
+  defp maybe_swap_alarm_handler(nil, config) do
+    :gen_event.add_handler(:alarm_handler, Alarmist.Handler, config)
+  end
+
+  defp maybe_swap_alarm_handler(old_handler, config) do
+    :gen_event.swap_handler(:alarm_handler, {old_handler, :swap}, {Alarmist.Handler, config})
+  end
+
+  # Find the first handler that would be a good one to swap out.
+  @swappable_handlers [:alarm_handler, Alarmist.Handler]
+  defp pick_handler([h | t], acc) when h in @swappable_handlers, do: {h, acc ++ t}
+  defp pick_handler([h | t], acc), do: pick_handler(t, [h | acc])
+  defp pick_handler([], acc), do: {nil, acc}
+
+  # Delete any handlers managed by Alarmist that aren't going to be swapped out.
+  # This really should never happen.
+  defp gc_handlers(handlers) do
+    handlers
+    |> Enum.filter(fn h -> h in @swappable_handlers end)
+    |> Enum.each(fn h ->
+      :gen_event.delete_handler(:alarm_handler, h, [])
+    end)
   end
 end


### PR DESCRIPTION
This PR addresses a problem that probably affects unit tests the most
where there's a race between application start and a call to the
handler. Amazingly, this was going unnoticed in tests due to the return
value from `:gen_event.call` not being checked. Most functions only
return `:ok` based on spec, so this wasn't expected. When this
manifested in an error, it was quite a bit later when some state wasn't
available.

There are two main pieces to this PR. One is to add retries to the
`:gen_event.call` calls so that users don't have to worry about the
race. The calls still obey the 5 second timeout with the retries. In the
future, it might be desirable to expose the timeout to users like is
frequently done with `GenServer.call`.

The second part of the PR is to clean up Application start and stop.
This is needed for the unit tests to actually use the new code and
reproduce the race. Otherwise the handler never gets removed and the
swap silently fails.
