### PR TITLE
Prevent failing gen_event calls when adding managed alarms

### DIFF
--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -337,9 +337,9 @@ defmodule Alarmist do
   @doc """
   Return all managed alarm IDs
   """
-  @spec managed_alarm_ids() :: [alarm_id()]
-  def managed_alarm_ids() do
-    Handler.managed_alarm_ids()
+  @spec managed_alarm_ids(timeout()) :: [alarm_id()]
+  def managed_alarm_ids(timeout \\ 5000) do
+    Handler.managed_alarm_ids(timeout)
   end
 
   @doc """

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -179,6 +179,21 @@ defmodule AlarmistTest do
     :ok
   end
 
+  test "raises with nice error if not running" do
+    _ =
+      capture_log(fn ->
+        Application.stop(:alarmist)
+
+        assert_raise RuntimeError,
+                     "Alarmist.Handler not found. Please ensure Alarmist is started before using it.",
+                     fn -> Alarmist.managed_alarm_ids(250) end
+
+        Application.start(:alarmist)
+      end)
+
+    :ok
+  end
+
   test "adding an invalid managed alarm logs a warning via application environment" do
     log =
       capture_log(fn ->


### PR DESCRIPTION
The retry mechanism can potentially end in a negative timeout number in situations where the handler is either missing or failing to start. This would result in a more confusing error rather than the intended RuntimeError made for these cases.

This fixes that to avoid creating negative timeouts during the retry loop. It may give up some milliseconds, but ensures the appropriate helpful error happens


```
** (EXIT from #PID<0.351.0>) an exception was raised:
     
          ** (FunctionClauseError) no function clause matching in :gen.call/4

          The following arguments were given to :gen.call/4:

              # 1
              :alarm_handler

              # 2
              #PID<0.352.0>

              # 3
              {:call, Alarmist.Handler, {:add_managed_alarm, MyAlarm, %{options: %{parameters: [], style: :atom}, rules: [{Alarmist.Ops, :debounce, [MyAlarm, MyAlarm.Requesting, 3600000]}], temporaries: []}}}

              # 4
              -15
```