### PR TITLE
Add sustain_window function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ iex> :alarm_handler.set_alarm({SomethingIsWrong, "Some optional description"})
 iex> :alarm_handler.clear_alarm(SomethingIsWrong)
 ```
 
-When you're at the IEx prompt, you can see the current alarm state in a few ways, but an easy way is to run `Alarmist.info/1`:
+When you're at the IEx prompt, you can see the current alarm state in a few
+ways, but an easy way is to run `Alarmist.info/1`:
 
 ```elixir
 iex> Alarmist.info
@@ -241,6 +242,30 @@ defmodule IntensityThresholdAlarm do
   alarm_if do
     # Set when raised and cleared >= 5 times in 3 seconds
     intensity(FlakyAlarm, 5, 3_000)
+  end
+end
+```
+
+### OnTime
+
+The `on_time/3` function sets an alarm when another has been accumulates over a
+certain amount of time being on over the course of an interval. An example of
+this is to handle an alarm that glitches on for short periods of time. Ignoring
+isolated glitches is the right thing to do, but if the accumulated alarm state
+exceeds a total amount of time in a period, then it's desirable to take action.
+
+Compare this with `intensity/3`. For `intensity/3`, it's the number of glitches
+in a period of time that matters. Long duration glitches (not really a glitch
+any more) don't affect the calculation. For `on_time/3`, it's the accumulated
+duration.
+
+```elixir
+defmodule OnTimeThresholdAlarm do
+  use Alarmist.Alarm
+
+  alarm_if do
+    # Set when 1 seconds of alarm time has accumulated in 3 seconds
+    on_time(FlakyAlarm, 1_000, 3_000)
   end
 end
 ```

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -104,11 +104,20 @@ defmodule Alarmist.Alarm do
   end
 
   @doc false
-  defmacro intensity(expression, count, time) do
+  defmacro intensity(expression, count, period) do
     expr_expanded = expand_expression(expression, __CALLER__)
 
-    quote bind_quoted: [count: count, time: time, expr_expanded: expr_expanded] do
-      [:intensity, expr_expanded, count, time]
+    quote bind_quoted: [count: count, period: period, expr_expanded: expr_expanded] do
+      [:intensity, expr_expanded, count, period]
+    end
+  end
+
+  @doc false
+  defmacro on_time(expression, on_time, period) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [on_time: on_time, period: period, expr_expanded: expr_expanded] do
+      [:on_time, expr_expanded, on_time, period]
     end
   end
 

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -121,6 +121,15 @@ defmodule Alarmist.Alarm do
     end
   end
 
+  @doc false
+  defmacro sustain_window(expression, on_time, period) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [on_time: on_time, period: period, expr_expanded: expr_expanded] do
+      [:sustain_window, expr_expanded, on_time, period]
+    end
+  end
+
   @doc """
   Define a managed alarm
 

--- a/lib/alarmist/compiler.ex
+++ b/lib/alarmist/compiler.ex
@@ -70,7 +70,7 @@ defmodule Alarmist.Compiler do
   end
 
   defp do_compile(state, [function1, input | params])
-       when function1 in [:debounce, :hold, :intensity, :on_time] do
+       when function1 in [:debounce, :hold, :intensity, :on_time, :sustain_window] do
     {state, [resolved_input]} = resolve(state, [input])
     {state, result} = make_variable(state)
     rule = mf(function1, [result, resolved_input | params])
@@ -81,7 +81,7 @@ defmodule Alarmist.Compiler do
   defp mf(:or, args), do: {Alarmist.Ops, :logical_or, args}
   defp mf(:not, args), do: {Alarmist.Ops, :logical_not, args}
 
-  defp mf(op, args) when op in [:copy, :debounce, :hold, :intensity, :on_time],
+  defp mf(op, args) when op in [:copy, :debounce, :hold, :intensity, :on_time, :sustain_window],
     do: {Alarmist.Ops, op, args}
 
   defp make_variable(state) do

--- a/lib/alarmist/compiler.ex
+++ b/lib/alarmist/compiler.ex
@@ -70,7 +70,7 @@ defmodule Alarmist.Compiler do
   end
 
   defp do_compile(state, [function1, input | params])
-       when function1 in [:debounce, :hold, :intensity] do
+       when function1 in [:debounce, :hold, :intensity, :on_time] do
     {state, [resolved_input]} = resolve(state, [input])
     {state, result} = make_variable(state)
     rule = mf(function1, [result, resolved_input | params])
@@ -81,7 +81,7 @@ defmodule Alarmist.Compiler do
   defp mf(:or, args), do: {Alarmist.Ops, :logical_or, args}
   defp mf(:not, args), do: {Alarmist.Ops, :logical_not, args}
 
-  defp mf(op, args) when op in [:copy, :debounce, :hold, :intensity],
+  defp mf(op, args) when op in [:copy, :debounce, :hold, :intensity, :on_time],
     do: {Alarmist.Ops, op, args}
 
   defp make_variable(state) do

--- a/lib/alarmist/engine.ex
+++ b/lib/alarmist/engine.ex
@@ -358,7 +358,7 @@ defmodule Alarmist.Engine do
 
   @doc false
   @spec start_timer(t(), Alarmist.alarm_id(), pos_integer(), Alarmist.alarm_state()) :: t()
-  def start_timer(engine, expiry_alarm_id, timeout_ms, value) do
+  def start_timer(engine, expiry_alarm_id, timeout_ms, value) when timeout_ms >= 0 do
     timer_id = make_ref()
     timer_action = {:start_timer, expiry_alarm_id, timeout_ms, value, timer_id}
 

--- a/lib/alarmist/window.ex
+++ b/lib/alarmist/window.ex
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.Window do
+  # Utilities for windowed alarm calculations
+
+  @moduledoc false
+
+  @type event_list() :: [{integer(), Alarmist.alarm_state()}]
+
+  @doc """
+  Add a set/clear event to a windowed event list
+
+  Using these functions ensures that the windowed event list properties
+  are maintained. The other functions in this module won't work if this
+  isn't the case. The rules are:
+
+  1. Newest event to oldest based on timestamp
+  2. Empty list means cleared for the entire window
+  3. Non-empty lists always end in a set event even if outside the window
+
+  `add_event/4` also garbage collects events that fall outside of the window.
+  """
+  @spec add_event(event_list(), Alarmist.alarm_state(), integer(), pos_integer()) :: event_list()
+  def add_event([], :clear, _now, _period), do: []
+  def add_event([], :set, now, _period), do: [{now, :set}]
+
+  def add_event([{first_time, first_status} | _] = events, status, now, period)
+      when now >= first_time and first_status != status do
+    too_old = now - period
+
+    [
+      {now, status}
+      | Enum.take_while(events, fn {t, s} -> t > too_old or s == :set end)
+    ]
+  end
+
+  # Callback for summing on-times and returning once a non-negative result once
+  # a threshold is crossed.
+  defp sum_threshold(delta, acc, threshold) do
+    new_acc = acc + delta
+
+    if new_acc >= threshold do
+      {threshold - acc, new_acc}
+    else
+      {-1, new_acc}
+    end
+  end
+
+  # Callback for checking if any on-time is beyond the threshold
+  defp any_threshold(delta, acc, threshold) do
+    if delta >= threshold do
+      {threshold, acc}
+    else
+      {-1, acc}
+    end
+  end
+
+  # Callback for counting on-times within the window and returning once
+  # a threshold count is reached.
+  defp count_threshold(_delta, acc, threshold) do
+    new_acc = acc + 1
+
+    if new_acc >= threshold do
+      # The trigger is at the very end of the delta (0 ms from the end)
+      {0, new_acc}
+    else
+      {-1, new_acc}
+    end
+  end
+
+  @doc """
+  Check if the cumulative alarm duration exceeds the threshold within the window.
+
+  Returns `{:set, time_to_clear}` if the total on-time within the window period
+  exceeds the threshold, or `{:clear, time_to_trigger}` otherwise.
+  """
+  @spec check_cumulative_alarm(event_list(), pos_integer(), pos_integer(), integer()) ::
+          {:set | :clear, integer()}
+  def check_cumulative_alarm(events, on_time, period, now) do
+    {out_status, onset_time, acc} =
+      onset_delta_time(events, now - period, now, &sum_threshold(&1, &2, on_time), 0)
+
+    case {out_status, List.first(events)} do
+      {:clear, {_, :set}} -> {:clear, on_time - acc}
+      {:set, {_, :clear}} -> {:set, period - (now - onset_time)}
+      _ -> {out_status, -1}
+    end
+  end
+
+  @doc """
+  Check if any single continuous alarm duration exceeds the threshold within the window.
+
+  Returns `{:set, time_to_clear}` if any continuous on-time within the window period
+  exceeds the threshold, or `{:clear, time_to_trigger}` otherwise.
+  """
+  @spec check_single_duration_alarm(event_list(), pos_integer(), pos_integer(), integer()) ::
+          {:set | :clear, integer()}
+  def check_single_duration_alarm(events, on_time, period, now) do
+    {out_status, onset_time, _acc} =
+      onset_delta_time(events, now - period, now, &any_threshold(&1, &2, on_time), 0)
+
+    case {out_status, List.first(events)} do
+      {:clear, {timestamp, :set}} -> {:clear, on_time - (now - timestamp)}
+      {:set, {_, :clear}} -> {:set, period - (now - onset_time)}
+      _ -> {out_status, -1}
+    end
+  end
+
+  @doc """
+  Check if the alarm transitions frequently enough to exceed the threshold within the window.
+
+  Returns `{:set, time_to_clear}` if the number of transitions within the window period
+  exceeds the threshold, or `{:clear, time_to_trigger}` otherwise.
+  """
+  @spec check_frequency_alarm(event_list(), pos_integer(), pos_integer(), integer()) ::
+          {:set | :clear, integer()}
+  def check_frequency_alarm(events, count, period, now) do
+    {out_status, onset_time, _acc} =
+      onset_delta_time(events, now - period, now, &count_threshold(&1, &2, count), 0)
+
+    if out_status == :set do
+      # This looks weird, but even if the input is set, if it doesn't toggle enough
+      # then it's not intense enough to trigger.
+      {:set, period - (now - onset_time)}
+    else
+      {:clear, -1}
+    end
+  end
+
+  # Process the event list to find the onset of the triggering condition
+  #
+  # If the triggering condition ends up being false, then `:infinity` is
+  # returned.
+  #
+  # The onset is the first time that contributes to a trigger condition.
+  # For example, if the trigger condition is 3 set/clear transitions, then
+  # the time from now to the 1st of the 3 set events is returned. If that
+  # first set was outside the window and the alarm continued to be set through
+  # the start of the window, then the beginning of the window to now is
+  # returned. The goal is that if the current state is clear, the calling
+  # code can subtract the return value from the window size to know how
+  # long the trigger condition will continue to be true without additional
+  # events.
+  defp onset_delta_time(
+         [],
+         _oldest_timestamp,
+         _last_timestamp,
+         _fun,
+         acc
+       ) do
+    # Rules 2 and 3 mean that any previous trigger events are outside of the window
+    # and were eligible to be dropped.
+    {:clear, 0, acc}
+  end
+
+  defp onset_delta_time(
+         [{timestamp, :set} | rest],
+         oldest_timestamp,
+         last_timestamp,
+         fun,
+         acc
+       ) do
+    delta_set = last_timestamp - max(timestamp, oldest_timestamp)
+    {time_triggered, new_acc} = fun.(delta_set, acc)
+
+    cond do
+      time_triggered >= 0 ->
+        {:set, last_timestamp - time_triggered, new_acc}
+
+      timestamp > oldest_timestamp ->
+        onset_delta_time(rest, oldest_timestamp, timestamp, fun, new_acc)
+
+      true ->
+        {:clear, 0, new_acc}
+    end
+  end
+
+  defp onset_delta_time(
+         [{timestamp, :clear} | rest],
+         oldest_timestamp,
+         _last_timestamp,
+         fun,
+         acc
+       ) do
+    onset_delta_time(rest, oldest_timestamp, timestamp, fun, acc)
+  end
+end

--- a/test/alarmist/alarm_if_test.exs
+++ b/test/alarmist/alarm_if_test.exs
@@ -117,6 +117,24 @@ defmodule Alarmist.AlarmIfTest do
     assert IntensityTest.__get_condition__() == expected_result
   end
 
+  test "on_time" do
+    defmodule OnTimeTest do
+      use Alarmist.Alarm
+
+      alarm_if do
+        on_time(AlarmId1, :timer.seconds(30), :timer.seconds(60))
+      end
+    end
+
+    expected_result = %{
+      rules: [{Alarmist.Ops, :on_time, [OnTimeTest, AlarmId1, 30000, 60000]}],
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
+    }
+
+    assert OnTimeTest.__get_condition__() == expected_result
+  end
+
   test "and and or" do
     defmodule AndOrTest do
       use Alarmist.Alarm

--- a/test/alarmist/window_test.exs
+++ b/test/alarmist/window_test.exs
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.WindowTest do
+  use ExUnit.Case, async: true
+  alias Alarmist.Window
+
+  describe "add_event/3" do
+    test "lone clears get dropped" do
+      assert Window.add_event([], :clear, 0, 100) == []
+    end
+
+    test "lone sets always kept" do
+      assert Window.add_event([], :set, 0, 100) == [{0, :set}]
+      assert Window.add_event([{-5000, :set}], :clear, 0, 100) == [{0, :clear}, {-5000, :set}]
+    end
+
+    test "raises if events added out of order" do
+      assert_raise FunctionClauseError, fn -> Window.add_event([{0, :set}], :clear, -10, 100) end
+    end
+
+    test "raises on redundant events" do
+      assert_raise FunctionClauseError, fn -> Window.add_event([{0, :set}], :set, -10, 100) end
+    end
+  end
+
+  describe "check_cumulative_alarm/4" do
+    test "cleared when clear" do
+      assert {:clear, -1} == Window.check_cumulative_alarm([], 50, 100, 0)
+    end
+
+    test "set for the whole interval" do
+      period = 100
+      events = [] |> Window.add_event(:set, -101, period)
+      assert {:set, -1} == Window.check_cumulative_alarm(events, 50, 100, 0)
+    end
+
+    test "sum across many events" do
+      events = [
+        {-10, :clear},
+        {-25, :set},
+        {-35, :clear},
+        {-50, :set},
+        {-60, :clear},
+        {-75, :set},
+        {-85, :clear},
+        {-100, :set},
+        {-110, :clear},
+        {-125, :set},
+        {-135, :clear},
+        {-150, :set}
+      ]
+
+      assert {:clear, -1} == Window.check_cumulative_alarm(events, 100, 200, -5)
+
+      # Window 200 ms, Set 90ms, cleared for 60ms in between sets. If no change, it
+      # should be set in 10ms
+      events = [{0, :set} | events]
+      assert {:clear, 10} = Window.check_cumulative_alarm(events, 100, 200, 0)
+
+      # Pretend that 5 ms when by, check that the time to wait for it to be set
+      # goes down.
+      assert {:clear, 5} = Window.check_cumulative_alarm(events, 100, 200, 5)
+
+      # Once 10 ms hits, it should be set for good.
+      assert {:set, -1} = Window.check_cumulative_alarm(events, 100, 200, 10)
+    end
+
+    test "expires when out of period" do
+      events = [
+        {0, :clear},
+        {-100, :set}
+      ]
+
+      # Should be set, but then revert to clear after 100 ms when
+      # the 100 ms on time in 200 ms requirement stops being met.
+      assert {:set, 100} == Window.check_cumulative_alarm(events, 100, 200, 0)
+
+      assert {:set, 50} == Window.check_cumulative_alarm(events, 100, 200, 50)
+      assert {:set, 0} == Window.check_cumulative_alarm(events, 100, 200, 100)
+      assert {:clear, -1} == Window.check_cumulative_alarm(events, 100, 200, 101)
+      assert {:clear, -1} == Window.check_cumulative_alarm(events, 100, 200, 200)
+    end
+  end
+
+  describe "check_single_duration_alarm/4" do
+    test "cleared when clear" do
+      assert {:clear, -1} == Window.check_single_duration_alarm([], 50, 100, 0)
+    end
+
+    test "set for the whole interval" do
+      period = 100
+      events = [] |> Window.add_event(:set, -101, period)
+      assert {:set, -1} == Window.check_single_duration_alarm(events, 50, 100, 0)
+    end
+
+    test "set for the partial interval" do
+      events = [{-80, :clear}, {-90, :set}]
+      assert {:clear, -1} == Window.check_single_duration_alarm(events, 50, 100, 0)
+
+      assert {:set, 10} == Window.check_single_duration_alarm(events, 10, 100, 0)
+      assert {:set, 15} == Window.check_single_duration_alarm(events, 5, 100, 0)
+    end
+
+    test "look across many events" do
+      events = [
+        {-36, :clear},
+        {-40, :set},
+        {-54, :clear},
+        {-60, :set},
+        {-72, :clear},
+        {-80, :set},
+        {-90, :clear},
+        {-100, :set}
+      ]
+
+      # No intervals are >10 ms
+      assert {:clear, -1} == Window.check_single_duration_alarm(events, 11, 200, 0)
+
+      # Test each exact size
+      assert {:set, 100} == Window.check_single_duration_alarm(events, 10, 200, 0)
+      assert {:set, 120} == Window.check_single_duration_alarm(events, 8, 200, 0)
+      assert {:set, 140} == Window.check_single_duration_alarm(events, 6, 200, 0)
+      assert {:set, 160} == Window.check_single_duration_alarm(events, 4, 200, 0)
+
+      # Test smaller sizes
+      assert {:set, 101} == Window.check_single_duration_alarm(events, 9, 200, 0)
+      assert {:set, 121} == Window.check_single_duration_alarm(events, 7, 200, 0)
+      assert {:set, 141} == Window.check_single_duration_alarm(events, 5, 200, 0)
+      assert {:set, 161} == Window.check_single_duration_alarm(events, 3, 200, 0)
+
+      assert {:set, 163} == Window.check_single_duration_alarm(events, 1, 200, 0)
+    end
+
+    test "expires when out of period" do
+      events = [
+        {0, :clear},
+        {-100, :set}
+      ]
+
+      # Should be set, but then revert to clear after 100 ms when
+      # the 100 ms on time in 200 ms requirement stops being met.
+      assert {:set, 100} == Window.check_single_duration_alarm(events, 100, 200, 0)
+
+      assert {:set, 50} == Window.check_single_duration_alarm(events, 100, 200, 50)
+      assert {:set, 0} == Window.check_single_duration_alarm(events, 100, 200, 100)
+      assert {:clear, -1} == Window.check_single_duration_alarm(events, 100, 200, 101)
+      assert {:clear, -1} == Window.check_single_duration_alarm(events, 100, 200, 200)
+    end
+  end
+
+  describe "check_frequency_alarm/4" do
+    test "cleared when not changing" do
+      assert {:clear, -1} == Window.check_frequency_alarm([], 1, 100, 0)
+      assert {:clear, -1} == Window.check_frequency_alarm([{-101, :set}], 2, 100, 0)
+    end
+
+    test "set when triggered and left clear" do
+      events = [
+        {-5, :clear},
+        {-6, :set},
+        {-7, :clear},
+        {-8, :set},
+        {-9, :clear},
+        {-10, :set}
+      ]
+
+      assert {:set, 91} == Window.check_frequency_alarm(events, 3, 100, 0)
+    end
+
+    test "set when triggered and left set" do
+      events = [
+        {-6, :set},
+        {-7, :clear},
+        {-8, :set},
+        {-9, :clear},
+        {-10, :set}
+      ]
+
+      assert {:set, 91} == Window.check_frequency_alarm(events, 3, 100, 0)
+    end
+
+    test "set when triggered by fast events" do
+      events = [
+        {0, :clear},
+        {0, :set},
+        {0, :clear},
+        {0, :set},
+        {0, :clear},
+        {0, :set}
+      ]
+
+      assert {:set, 100} == Window.check_frequency_alarm(events, 3, 100, 0)
+    end
+  end
+end

--- a/test/integration/intensity_test.exs
+++ b/test/integration/intensity_test.exs
@@ -42,4 +42,19 @@ defmodule Integration.IntensityTest do
     Alarmist.remove_managed_alarm(IntensityAlarm)
     :alarm_handler.clear_alarm(IntensityTriggerAlarm)
   end
+
+  test "redundant sets are ignored" do
+    Alarmist.subscribe(IntensityAlarm)
+    Alarmist.add_managed_alarm(IntensityAlarm)
+
+    Enum.each(1..50, fn i ->
+      :alarm_handler.set_alarm({IntensityTriggerAlarm, i})
+      Process.sleep(1)
+    end)
+
+    refute_receive _, 10
+
+    Alarmist.remove_managed_alarm(IntensityAlarm)
+    :alarm_handler.clear_alarm(IntensityTriggerAlarm)
+  end
 end

--- a/test/integration/on_time_test.exs
+++ b/test/integration/on_time_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SmartRent Technologies, Inc.
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/test/integration/on_time_test.exs
+++ b/test/integration/on_time_test.exs
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2023 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Integration.OnTimeTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    on_exit(fn -> AlarmUtilities.assert_clean_state() end)
+  end
+
+  test "basic case" do
+    Alarmist.subscribe(OnTimeAlarm)
+    Alarmist.add_managed_alarm(OnTimeAlarm)
+
+    # Alarm gets raised when >100ms in a 200ms period
+    :alarm_handler.set_alarm({OnTimeTriggerAlarm, "basic"})
+    refute_receive _, 50
+
+    # Give the on_time alarm 50ms slack for slow CI
+    assert_receive %Alarmist.Event{
+                     id: OnTimeAlarm,
+                     state: :set
+                   },
+                   100
+
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+
+    # It will go away in 100 ms
+    assert_receive %Alarmist.Event{
+                     id: OnTimeAlarm,
+                     state: :clear
+                   },
+                   150
+
+    Alarmist.remove_managed_alarm(OnTimeAlarm)
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+  end
+
+  test "accumulated case" do
+    Alarmist.subscribe(OnTimeAlarm)
+    Alarmist.add_managed_alarm(OnTimeAlarm)
+
+    # Alarm gets raised when >100ms in a 200ms period
+    Enum.each(1..6, fn i ->
+      :alarm_handler.set_alarm({OnTimeTriggerAlarm, i})
+      refute_receive _, 15
+      :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+      refute_receive _, 10
+    end)
+
+    # 90 ms on, 60 ms off at this point
+    :alarm_handler.set_alarm({OnTimeTriggerAlarm, 7})
+
+    assert_receive %Alarmist.Event{
+                     id: OnTimeAlarm,
+                     state: :set
+                   },
+                   15
+
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+
+    # 100 ms on, 60 ms off here hopefully
+    refute_receive _, 10
+
+    # 100 ms on, 80 ms off
+    assert_receive %Alarmist.Event{
+                     id: OnTimeAlarm,
+                     state: :clear
+                   },
+                   50
+
+    Alarmist.remove_managed_alarm(OnTimeAlarm)
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+  end
+
+  test "redundant sets are ignored" do
+    Alarmist.subscribe(OnTimeAlarm)
+    Alarmist.add_managed_alarm(OnTimeAlarm)
+
+    # The core implementation has an assumption that there are no
+    # duplicate alarm notifications. If the duplicate clear alarms
+    # were received, it would cause the code to do the wrong thing.
+    # The sleeps are just to let the alarm processing code run.
+    :alarm_handler.set_alarm({OnTimeTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.set_alarm({OnTimeTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+    refute_receive _, 1
+
+    refute_receive _, 500
+
+    Alarmist.remove_managed_alarm(OnTimeAlarm)
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+  end
+
+  test "redundant clears are ignored" do
+    Alarmist.subscribe(OnTimeAlarm)
+    Alarmist.add_managed_alarm(OnTimeAlarm)
+
+    # The core implementation has an assumption that there are no
+    # duplicate alarm notifications. If the duplicate clear alarms
+    # were received, it would cause the code to do the wrong thing.
+    # The sleeps are just to let the alarm processing code run.
+    :alarm_handler.set_alarm({OnTimeTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+    refute_receive _, 1
+
+    refute_receive _, 500
+
+    Alarmist.remove_managed_alarm(OnTimeAlarm)
+    :alarm_handler.clear_alarm(OnTimeTriggerAlarm)
+  end
+end

--- a/test/integration/sustain_window_test.exs
+++ b/test/integration/sustain_window_test.exs
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Integration.SustainWindowTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    on_exit(fn -> AlarmUtilities.assert_clean_state() end)
+  end
+
+  test "basic case" do
+    Alarmist.subscribe(SustainWindowAlarm)
+    Alarmist.add_managed_alarm(SustainWindowAlarm)
+
+    # Alarm gets raised when >100ms in a 200ms period
+    :alarm_handler.set_alarm({SustainWindowTriggerAlarm, "basic"})
+    refute_receive _, 50
+
+    # Give the on_time alarm 50ms slack for slow CI
+    assert_receive %Alarmist.Event{
+                     id: SustainWindowAlarm,
+                     state: :set
+                   },
+                   100
+
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+
+    # It will go away in 100 ms
+    assert_receive %Alarmist.Event{
+                     id: SustainWindowAlarm,
+                     state: :clear
+                   },
+                   150
+
+    Alarmist.remove_managed_alarm(SustainWindowAlarm)
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+  end
+
+  test "no trigger on accumulation" do
+    Alarmist.subscribe(SustainWindowAlarm)
+    Alarmist.add_managed_alarm(SustainWindowAlarm)
+
+    # Alarm gets raised when >100ms in a 200ms period
+    Enum.each(1..6, fn i ->
+      :alarm_handler.set_alarm({SustainWindowTriggerAlarm, i})
+      refute_receive _, 20
+      :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+      refute_receive _, 1
+    end)
+
+    # 120 ms on in 20 ms chunks, 6 ms off at this point
+    # No alarm should have been set above.
+
+    Alarmist.remove_managed_alarm(SustainWindowAlarm)
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+  end
+
+  test "redundant sets are ignored" do
+    Alarmist.subscribe(SustainWindowAlarm)
+    Alarmist.add_managed_alarm(SustainWindowAlarm)
+
+    # The core implementation has an assumption that there are no
+    # duplicate alarm notifications. If the duplicate clear alarms
+    # were received, it would cause the code to do the wrong thing.
+    # The sleeps are just to let the alarm processing code run.
+    :alarm_handler.set_alarm({SustainWindowTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.set_alarm({SustainWindowTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+    refute_receive _, 1
+
+    refute_receive _, 500
+
+    Alarmist.remove_managed_alarm(SustainWindowAlarm)
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+  end
+
+  test "redundant clears are ignored" do
+    Alarmist.subscribe(SustainWindowAlarm)
+    Alarmist.add_managed_alarm(SustainWindowAlarm)
+
+    # The core implementation has an assumption that there are no
+    # duplicate alarm notifications. If the duplicate clear alarms
+    # were received, it would cause the code to do the wrong thing.
+    # The sleeps are just to let the alarm processing code run.
+    :alarm_handler.set_alarm({SustainWindowTriggerAlarm, "redundant"})
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+    refute_receive _, 1
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+    refute_receive _, 1
+
+    refute_receive _, 500
+
+    Alarmist.remove_managed_alarm(SustainWindowAlarm)
+    :alarm_handler.clear_alarm(SustainWindowTriggerAlarm)
+  end
+end

--- a/test/support/on_time_alarm.ex
+++ b/test/support/on_time_alarm.ex
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule OnTimeAlarm do
+  use Alarmist.Alarm
+
+  alarm_if do
+    on_time(OnTimeTriggerAlarm, 100, 200)
+  end
+end

--- a/test/support/sustain_window_alarm.ex
+++ b/test/support/sustain_window_alarm.ex
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule SustainWindowAlarm do
+  use Alarmist.Alarm
+
+  alarm_if do
+    sustain_window(SustainWindowTriggerAlarm, 100, 200)
+  end
+end


### PR DESCRIPTION
This makes it more clear than combining debounce/hold that the intent is
to require an alarm to be on for at least a duration straight within a
window.

This stacks on the windowed PR refactoring.
