### PR TITLE
Add timestamp helper function; use DateTime for conversion

### DIFF
--- a/lib/alarmist/event.ex
+++ b/lib/alarmist/event.ex
@@ -10,11 +10,9 @@ defmodule Alarmist.Event do
   * `:state` - `:set` or `:clear`
   * `:description` - alarm description or `nil` when the alarm has been cleared
   * `:level` - alarm severity if known to Alarmist. Defaults to `:warning`
-  * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened
-  * `:previous_state` - the previous value (`:unknown` if no previous information)
-  * `:previous_timestamp` - the timestamp when the property changed to
-    `:previous_state`. Use this to calculate how long the property was the
-    previous state.
+  * `:timestamp` - the timestamp (`System.monotonic_time/0`) when the changed happened. See `timestamp_to_utc/2` for UTC conversion.
+  * `:previous_state` - the previous alarm state (`:unknown` if no previous information).
+  * `:previous_timestamp` - the timestamp when the property changed to `:previous_state`. See `timestamp_to_utc/2` for UTC conversion.
   """
   defstruct [:id, :state, :description, :level, :timestamp, :previous_state, :previous_timestamp]
 
@@ -27,6 +25,28 @@ defmodule Alarmist.Event do
           timestamp: integer(),
           previous_timestamp: integer()
         }
+
+  @doc """
+  Convert the event's monotonic timestamp to UTC
+  """
+  @spec timestamp_to_utc(integer(), {integer(), DateTime.t()}) :: DateTime.t()
+  def timestamp_to_utc(timestamp, {monotonic, utc} \\ utc_conversion()) do
+    offset = System.convert_time_unit(timestamp - monotonic, :native, :microsecond)
+    DateTime.add(utc, offset, :microsecond)
+  end
+
+  @doc """
+  Returns a monotonic time to UTC time mapping
+
+  This is used by `timestamp_to_utc/2` by default, but it's possible to supply
+  a custom mapping for unit test or performance reasons.
+
+  The monotonic time is in native time units.
+  """
+  @spec utc_conversion() :: {integer(), DateTime.t()}
+  def utc_conversion() do
+    {System.monotonic_time(), DateTime.utc_now()}
+  end
 
   @doc false
   @spec from_property_table(PropertyTable.Event.t()) :: t()

--- a/test/alarmist/event_test.exs
+++ b/test/alarmist/event_test.exs
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.EventTest do
+  use ExUnit.Case
+
+  describe "timestamp_to_utc/2" do
+    test "converts monotonic timestamp to UTC" do
+      monotonic = System.monotonic_time()
+      utc = DateTime.utc_now()
+
+      assert Alarmist.Event.timestamp_to_utc(monotonic, {monotonic, utc}) == utc
+
+      monotonic_plus_1m = monotonic + System.convert_time_unit(60, :second, :native)
+      utc_plus_1m = DateTime.add(utc, 60, :second)
+
+      assert Alarmist.Event.timestamp_to_utc(monotonic_plus_1m, {monotonic, utc}) == utc_plus_1m
+    end
+  end
+end

--- a/test/alarmist/info_test.exs
+++ b/test/alarmist/info_test.exs
@@ -37,26 +37,26 @@ defmodule Alarmist.InfoTest do
         level: :debug,
         ansi_enabled?: false,
         monotonic_now: now,
-        utc_now: ~N[2025-05-26 18:44:39]
+        utc_now: ~U[2025-05-26 18:44:39Z]
       ]
 
       expected = """
-                                          Set Alarms
-      SEVERITY   ALARM ID            LAST CHANGE                   DESCRIPTION
-      Emergency  NetworkDown         2025-05-26 18:42:39 (2m 0s)   A long description
-      Alert      ThatsBad            2025-05-26 18:36:39 (8m 0s)   Something else
-      Critical   CatastropheEminent  2025-05-26 18:41:39 (3m 0s)
-      Error      AError              2025-05-26 18:37:39 (7m 0s)   who knows
-      Error      BError              2025-05-26 18:38:39 (6m 0s)   who knows
-      Error      CError              2025-05-26 18:39:39 (5m 0s)   who knows
-      Warning    Hello               2025-05-26 18:34:39 (10m 0s)  123
-      Notice     YouShouldKnowThis   2025-05-26 18:33:39 (11m 0s)  %{key: 1}
-      Info       JustSaying          2025-05-26 18:32:39 (12m 0s)  Don't worry about this
-      Debug      Debug               2025-05-26 18:40:39 (4m 0s)   Debug debug debug
+                                           Set Alarms
+      SEVERITY   ALARM ID            LAST CHANGE                    DESCRIPTION
+      Emergency  NetworkDown         2025-05-26 18:42:39Z (2m 0s)   A long description
+      Alert      ThatsBad            2025-05-26 18:36:39Z (8m 0s)   Something else
+      Critical   CatastropheEminent  2025-05-26 18:41:39Z (3m 0s)
+      Error      AError              2025-05-26 18:37:39Z (7m 0s)   who knows
+      Error      BError              2025-05-26 18:38:39Z (6m 0s)   who knows
+      Error      CError              2025-05-26 18:39:39Z (5m 0s)   who knows
+      Warning    Hello               2025-05-26 18:34:39Z (10m 0s)  123
+      Notice     YouShouldKnowThis   2025-05-26 18:33:39Z (11m 0s)  %{key: 1}
+      Info       JustSaying          2025-05-26 18:32:39Z (12m 0s)  Don't worry about this
+      Debug      Debug               2025-05-26 18:40:39Z (4m 0s)   Debug debug debug
 
-                                        Cleared Alarms
-      SEVERITY   ALARM ID            LAST CHANGE                   DESCRIPTION
-      Warning    ClearedAlarm        2025-05-26 18:35:39 (9m 0s)
+                                         Cleared Alarms
+      SEVERITY   ALARM ID            LAST CHANGE                    DESCRIPTION
+      Warning    ClearedAlarm        2025-05-26 18:35:39Z (9m 0s)
 
       """
 


### PR DESCRIPTION
Alarmist timestamps are always in native monotonic time units but that's
not ideal for users looking at or logging the alarms. This adds a simple
conversion utility.

This also switches from NaiveDateTime to DateTime so that the time zone
is included.
