### PR TITLE
Reduce number of intermediates with tuple alarm ids

### DIFF
--- a/lib/alarmist/compiler.ex
+++ b/lib/alarmist/compiler.ex
@@ -96,8 +96,8 @@ defmodule Alarmist.Compiler do
     {state, Enum.reverse(result)}
   end
 
-  defp resolve(state, [alarm_type | rest], result) when is_atom(alarm_type) do
-    resolve(state, rest, [alarm_type | result])
+  defp resolve(state, [alarm_id | rest], result) when is_alarm_id(alarm_id) do
+    resolve(state, rest, [alarm_id | result])
   end
 
   defp resolve(state, [value | rest], result) do

--- a/test/alarmist/alarm_if_test.exs
+++ b/test/alarmist/alarm_if_test.exs
@@ -24,6 +24,51 @@ defmodule Alarmist.AlarmIfTest do
     assert IdentityTest.__get_condition_source__() == "MyAlarmId"
   end
 
+  test "parameterized identity" do
+    defmodule ParameterizedIdentityTest do
+      use Alarmist.Alarm
+
+      alarm_if do
+        {MyAlarmId, "eth0"}
+      end
+    end
+
+    expected_result = %{
+      rules: [{Alarmist.Ops, :copy, [ParameterizedIdentityTest, {MyAlarmId, "eth0"}]}],
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
+    }
+
+    assert ParameterizedIdentityTest.__get_condition__() == expected_result
+  end
+
+  test "parameterized identity2" do
+    defmodule ParameterizedIdentityTest2 do
+      use Alarmist.Alarm, style: :tagged_tuple, parameters: [:parameter1]
+
+      alarm_if do
+        {MyAlarmId, parameter1}
+      end
+    end
+
+    expected_result = %{
+      options: %{parameters: [:parameter1], style: :tagged_tuple},
+      rules: [
+        {
+          Alarmist.Ops,
+          :copy,
+          [
+            {:alarm_id, {Alarmist.AlarmIfTest.ParameterizedIdentityTest2, :parameter1}},
+            {:alarm_id, {MyAlarmId, :parameter1}}
+          ]
+        }
+      ],
+      temporaries: []
+    }
+
+    assert ParameterizedIdentityTest2.__get_condition__() == expected_result
+  end
+
   test "and" do
     defmodule AndTest do
       use Alarmist.Alarm


### PR DESCRIPTION
This also adds more tests since this was subtle.
