### PR TITLE
Fix unknown/clear ambiguities on alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ doesn't know what network interfaces are available, so application code needs
 to call `Alarmist.add_managed_alarm/1` with each possibility. I.e.,
 `Alarmist.add_managed_alarm({NetworkDownAlarm, "eth0"})`
 
+### Unknown alarm handling
+
+Alarm IDs that haven't been set or cleared yet are reported as `:unknown`.
+These alarms could just be due to initialization order where the code that
+reports them hasn't run yet. They could also be due to an Alarm ID being
+misspelled.
+
+Managed alarms treat unknown alarms as cleared in `alarm_if` expressions.
+
+Lastly, Alarmist transitions managed alarm IDs to the `:unknown` state in
+`Alarmist.remove_managed_alarm/1`. While it's not common for managed alarms to
+be removed in production use, if they were, any code listening for events from
+them would notice it.
+
 ## Managed alarm operators
 
 Managed alarms defined with `alarm_if` support boolean operators and a few

--- a/lib/alarmist/handler.ex
+++ b/lib/alarmist/handler.ex
@@ -129,7 +129,7 @@ defmodule Alarmist.Handler do
   end
 
   defp lookup(alarm_id) do
-    {op, description, _level} = PropertyTable.get(Alarmist, alarm_id, {:clear, nil, :debug})
+    {op, description, _level} = PropertyTable.get(Alarmist, alarm_id, {:unknown, nil, :debug})
     {op, description}
   end
 
@@ -229,6 +229,10 @@ defmodule Alarmist.Handler do
 
   defp run_side_effect({:clear, alarm_id, _, level}) do
     PropertyTable.put(Alarmist, alarm_id, {:clear, nil, level})
+  end
+
+  defp run_side_effect({:forget, alarm_id}) do
+    PropertyTable.delete(Alarmist, alarm_id)
   end
 
   defp run_side_effect({:start_timer, alarm_id, timeout, what, params}) do

--- a/lib/alarmist/ops.ex
+++ b/lib/alarmist/ops.ex
@@ -33,7 +33,7 @@ defmodule Alarmist.Ops do
   """
   @spec copy(engine(), [Alarmist.alarm_id()]) :: engine()
   def copy(engine, [output, input]) do
-    {engine, {state, description}} = Engine.cache_get(engine, input)
+    {engine, {state, description}} = Engine.cache_get(engine, input, {:clear, nil})
     Engine.cache_put(engine, output, state, description)
   end
 
@@ -57,7 +57,7 @@ defmodule Alarmist.Ops do
   """
   @spec logical_not(engine(), [Alarmist.alarm_id()]) :: engine()
   def logical_not(engine, [output, input]) do
-    {engine, {state, _description}} = Engine.cache_get(engine, input)
+    {engine, {state, _description}} = Engine.cache_get(engine, input, {:clear, nil})
 
     new_state = if state == :clear, do: :set, else: :clear
     Engine.cache_put(engine, output, new_state, nil)
@@ -95,7 +95,7 @@ defmodule Alarmist.Ops do
   end
 
   defp do_logical_and(engine, [input | rest]) do
-    {engine, {state, _}} = Engine.cache_get(engine, input)
+    {engine, {state, _}} = Engine.cache_get(engine, input, {:clear, nil})
 
     case state do
       :set -> do_logical_and(engine, rest)
@@ -135,7 +135,7 @@ defmodule Alarmist.Ops do
   end
 
   defp do_logical_or(engine, [input | rest]) do
-    {engine, {state, _}} = Engine.cache_get(engine, input)
+    {engine, {state, _}} = Engine.cache_get(engine, input, {:clear, nil})
 
     if state == :clear do
       do_logical_or(engine, rest)
@@ -177,7 +177,7 @@ defmodule Alarmist.Ops do
   """
   @spec debounce(engine(), [Alarmist.alarm_id(), ...]) :: engine()
   def debounce(engine, [output, input, timeout]) do
-    {engine, value} = Engine.cache_get(engine, input)
+    {engine, value} = Engine.cache_get(engine, input, {:clear, nil})
 
     case value do
       {:clear, _} ->
@@ -218,7 +218,7 @@ defmodule Alarmist.Ops do
   """
   @spec hold(engine(), [Alarmist.alarm_id(), ...]) :: engine()
   def hold(engine, [output, input, timeout]) do
-    {engine, value} = Engine.cache_get(engine, input)
+    {engine, value} = Engine.cache_get(engine, input, {:clear, nil})
 
     case value do
       {:clear, _} ->
@@ -264,7 +264,7 @@ defmodule Alarmist.Ops do
   def intensity(engine, [output, input, count, period]) do
     now = System.monotonic_time(:millisecond)
 
-    {engine, {status, _description}} = Engine.cache_get(engine, input)
+    {engine, {status, _description}} = Engine.cache_get(engine, input, {:clear, nil})
 
     events =
       Engine.get_state(engine, output, [])
@@ -306,7 +306,7 @@ defmodule Alarmist.Ops do
   def on_time(engine, [output, input, on_time, period]) do
     now = System.monotonic_time(:millisecond)
 
-    {engine, {status, _description}} = Engine.cache_get(engine, input)
+    {engine, {status, _description}} = Engine.cache_get(engine, input, {:clear, nil})
 
     events =
       Engine.get_state(engine, output, [])
@@ -353,7 +353,7 @@ defmodule Alarmist.Ops do
   def sustain_window(engine, [output, input, on_time, period]) do
     now = System.monotonic_time(:millisecond)
 
-    {engine, {status, _description}} = Engine.cache_get(engine, input)
+    {engine, {status, _description}} = Engine.cache_get(engine, input, {:clear, nil})
 
     events =
       Engine.get_state(engine, output, [])

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -272,9 +272,10 @@ defmodule AlarmistTest do
 
   test "adding an alarm many times" do
     Alarmist.subscribe(IdentityAlarm)
-    :alarm_handler.set_alarm({IdentityTriggerAlarm, nil})
 
     Alarmist.add_managed_alarm(IdentityAlarm)
+    assert_receive %Alarmist.Event{id: IdentityAlarm, state: :clear}
+    :alarm_handler.set_alarm({IdentityTriggerAlarm, nil})
     assert_receive %Alarmist.Event{id: IdentityAlarm, state: :set}
     refute_received _
 
@@ -541,7 +542,7 @@ defmodule AlarmistTest do
     :alarm_handler.clear_alarm(IdentityTriggerAlarm)
   end
 
-  test "cleared when rule deleted" do
+  test "unknown when managed rule deleted" do
     Alarmist.subscribe(IdentityAlarm)
     Alarmist.add_managed_alarm(IdentityAlarm)
 
@@ -550,6 +551,8 @@ defmodule AlarmistTest do
     assert_receive %Alarmist.Event{id: IdentityAlarm, state: :set}
 
     Alarmist.remove_managed_alarm(IdentityAlarm)
+    assert_receive %Alarmist.Event{id: IdentityAlarm, state: :unknown}
+
     :alarm_handler.clear_alarm(IdentityTriggerAlarm)
   end
 

--- a/test/integration/boolean_test.exs
+++ b/test/integration/boolean_test.exs
@@ -24,7 +24,7 @@ defmodule Integration.BooleanTest do
     refute_received _
 
     Alarmist.add_managed_alarm(TestAlarm)
-    refute_received _
+    assert_receive %Alarmist.Event{id: TestAlarm, state: :clear}
 
     :alarm_handler.set_alarm({AlarmId1, nil})
     refute_received _
@@ -47,7 +47,7 @@ defmodule Integration.BooleanTest do
     refute_received _
 
     Alarmist.add_managed_alarm(NotNotAlarm)
-    refute_received _
+    assert_receive %Alarmist.Event{id: NotNotAlarm, state: :clear}
 
     :alarm_handler.set_alarm({NotNotTriggerAlarm, nil})
 

--- a/test/integration/debounce_test.exs
+++ b/test/integration/debounce_test.exs
@@ -11,18 +11,19 @@ defmodule Integration.DebounceTest do
     on_exit(fn -> AlarmUtilities.assert_clean_state() end)
   end
 
-  test "debounce rules" do
-    defmodule DebounceAlarm do
-      use Alarmist.Alarm
+  defmodule DebounceAlarm do
+    use Alarmist.Alarm
 
-      alarm_if do
-        debounce(DebounceTriggerAlarm, 100)
-      end
+    alarm_if do
+      debounce(DebounceTriggerAlarm, 100)
     end
+  end
 
+  test "debounce rules" do
     Alarmist.subscribe(DebounceAlarm)
     Alarmist.subscribe(DebounceTriggerAlarm)
     Alarmist.add_managed_alarm(DebounceAlarm)
+    assert_receive %Alarmist.Event{id: DebounceAlarm, state: :clear}
 
     # Test the transient case
     :alarm_handler.set_alarm({DebounceTriggerAlarm, nil})
@@ -49,11 +50,15 @@ defmodule Integration.DebounceTest do
     assert_receive %Alarmist.Event{id: DebounceTriggerAlarm, state: :clear}
 
     Alarmist.remove_managed_alarm(DebounceAlarm)
+    Alarmist.unsubscribe(DebounceAlarm)
+    Alarmist.unsubscribe(DebounceTriggerAlarm)
   end
 
   test "debounce transient set-clear-set" do
     Alarmist.subscribe(DebounceAlarm)
+    assert Alarmist.alarm_state(DebounceAlarm) == :unknown
     Alarmist.add_managed_alarm(DebounceAlarm)
+    assert_receive %Alarmist.Event{id: DebounceAlarm, state: :clear}, 200
 
     :alarm_handler.set_alarm({DebounceTriggerAlarm, nil})
     :alarm_handler.clear_alarm(DebounceTriggerAlarm)
@@ -65,12 +70,15 @@ defmodule Integration.DebounceTest do
     refute_receive _, 200
 
     Alarmist.remove_managed_alarm(DebounceAlarm)
+    assert_receive %Alarmist.Event{id: DebounceAlarm, state: :unknown}
     :alarm_handler.clear_alarm(DebounceTriggerAlarm)
+    refute_receive _
   end
 
   test "debounce transient clear-set-clear" do
     Alarmist.subscribe(DebounceAlarm)
     Alarmist.add_managed_alarm(DebounceAlarm)
+    assert_receive %Alarmist.Event{id: DebounceAlarm, state: :clear}
 
     :alarm_handler.clear_alarm(DebounceTriggerAlarm)
     :alarm_handler.set_alarm({DebounceTriggerAlarm, nil})

--- a/test/integration/hold_test.exs
+++ b/test/integration/hold_test.exs
@@ -15,39 +15,18 @@ defmodule Integration.HoldTest do
     Alarmist.subscribe(HoldAlarm)
     Alarmist.subscribe(HoldTriggerAlarm)
     Alarmist.add_managed_alarm(HoldAlarm)
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear}
+
     :alarm_handler.set_alarm({HoldTriggerAlarm, nil})
-
-    assert_receive %Alarmist.Event{
-      id: HoldAlarm,
-      state: :set,
-      description: nil
-    }
-
-    assert_receive %Alarmist.Event{
-      id: HoldTriggerAlarm,
-      state: :set,
-      description: nil
-    }
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :set, description: nil}
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :set, description: nil}
 
     :alarm_handler.clear_alarm(HoldTriggerAlarm)
-
-    assert_receive %Alarmist.Event{
-      id: HoldTriggerAlarm,
-      state: :clear,
-      description: nil,
-      previous_state: :set
-    }
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :clear, previous_state: :set}
 
     refute_receive _
 
-    Process.sleep(250)
-
-    assert_receive %Alarmist.Event{
-      id: HoldAlarm,
-      state: :clear,
-      description: nil,
-      previous_state: :set
-    }
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear, previous_state: :set}, 250
 
     Alarmist.remove_managed_alarm(HoldAlarm)
   end

--- a/test/integration/intensity_test.exs
+++ b/test/integration/intensity_test.exs
@@ -14,6 +14,7 @@ defmodule Integration.IntensityTest do
   test "intensity rules" do
     Alarmist.subscribe(IntensityAlarm)
     Alarmist.add_managed_alarm(IntensityAlarm)
+    assert_receive %Alarmist.Event{id: IntensityAlarm, state: :clear}
 
     # Hammer out the alarms.
     :alarm_handler.set_alarm({IntensityTriggerAlarm, 1})
@@ -46,6 +47,7 @@ defmodule Integration.IntensityTest do
   test "redundant sets are ignored" do
     Alarmist.subscribe(IntensityAlarm)
     Alarmist.add_managed_alarm(IntensityAlarm)
+    assert_receive %Alarmist.Event{id: IntensityAlarm, state: :clear}
 
     Enum.each(1..50, fn i ->
       :alarm_handler.set_alarm({IntensityTriggerAlarm, i})

--- a/test/integration/on_time_test.exs
+++ b/test/integration/on_time_test.exs
@@ -14,6 +14,7 @@ defmodule Integration.OnTimeTest do
   test "basic case" do
     Alarmist.subscribe(OnTimeAlarm)
     Alarmist.add_managed_alarm(OnTimeAlarm)
+    assert_receive %Alarmist.Event{id: OnTimeAlarm, state: :clear}
 
     # Alarm gets raised when >100ms in a 200ms period
     :alarm_handler.set_alarm({OnTimeTriggerAlarm, "basic"})
@@ -42,6 +43,7 @@ defmodule Integration.OnTimeTest do
   test "accumulated case" do
     Alarmist.subscribe(OnTimeAlarm)
     Alarmist.add_managed_alarm(OnTimeAlarm)
+    assert_receive %Alarmist.Event{id: OnTimeAlarm, state: :clear}
 
     # Alarm gets raised when >100ms in a 200ms period
     Enum.each(1..6, fn i ->
@@ -79,6 +81,7 @@ defmodule Integration.OnTimeTest do
   test "redundant sets are ignored" do
     Alarmist.subscribe(OnTimeAlarm)
     Alarmist.add_managed_alarm(OnTimeAlarm)
+    assert_receive %Alarmist.Event{id: OnTimeAlarm, state: :clear}
 
     # The core implementation has an assumption that there are no
     # duplicate alarm notifications. If the duplicate clear alarms
@@ -100,6 +103,7 @@ defmodule Integration.OnTimeTest do
   test "redundant clears are ignored" do
     Alarmist.subscribe(OnTimeAlarm)
     Alarmist.add_managed_alarm(OnTimeAlarm)
+    assert_receive %Alarmist.Event{id: OnTimeAlarm, state: :clear}
 
     # The core implementation has an assumption that there are no
     # duplicate alarm notifications. If the duplicate clear alarms

--- a/test/integration/parameterized_test.exs
+++ b/test/integration/parameterized_test.exs
@@ -15,7 +15,8 @@ defmodule Integration.ParameterizedTest do
     Alarmist.subscribe({IdentityTuple1Alarm, :_})
     Alarmist.add_managed_alarm({IdentityTuple1Alarm, "eth0"})
     Alarmist.add_managed_alarm({IdentityTuple1Alarm, "wlan0"})
-    refute_received _
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "eth0"}, state: :clear}
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "wlan0"}, state: :clear}
 
     :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "eth0"}, nil})
     assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "eth0"}, state: :set}
@@ -29,9 +30,11 @@ defmodule Integration.ParameterizedTest do
     :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "wlan0"})
     assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "wlan0"}, state: :clear}
 
-    refute_receive _
     Alarmist.remove_managed_alarm({IdentityTuple1Alarm, "eth0"})
     Alarmist.remove_managed_alarm({IdentityTuple1Alarm, "wlan0"})
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "eth0"}, state: :unknown}
+    assert_receive %Alarmist.Event{id: {IdentityTuple1Alarm, "wlan0"}, state: :unknown}
+    Alarmist.unsubscribe({IdentityTuple1Alarm, :_})
   end
 
   test "parameterized trigger alarm" do
@@ -68,6 +71,7 @@ defmodule Integration.ParameterizedTest do
     Alarmist.add_managed_alarm({CompoundTuple1Alarm, "wlan0"})
     assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "eth0"}, state: :set}
     assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "wlan0"}, state: :set}
+    refute_received _
 
     :alarm_handler.set_alarm({{CompoundTuple1Trigger2Alarm, "eth0"}, nil})
     assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "eth0"}, state: :clear}
@@ -82,7 +86,7 @@ defmodule Integration.ParameterizedTest do
 
     Alarmist.remove_managed_alarm({CompoundTuple1Alarm, "eth0"})
     Alarmist.remove_managed_alarm({CompoundTuple1Alarm, "wlan0"})
-    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "wlan0"}, state: :clear}
+    assert_receive %Alarmist.Event{id: {CompoundTuple1Alarm, "wlan0"}, state: :unknown}
     :alarm_handler.clear_alarm(GlobalTriggerAlarm)
     :alarm_handler.clear_alarm({CompoundTuple1Trigger2Alarm, "eth0"})
   end
@@ -90,7 +94,7 @@ defmodule Integration.ParameterizedTest do
   test "two parameter identity" do
     Alarmist.subscribe({IdentityTuple2Alarm, :_, :_})
     Alarmist.add_managed_alarm({IdentityTuple2Alarm, "param1", "param2"})
-    refute_received _
+    assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :clear}
 
     :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "param1", "param2"}, nil})
     assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :set}
@@ -98,14 +102,20 @@ defmodule Integration.ParameterizedTest do
     :alarm_handler.clear_alarm({IdentityTupleTriggerAlarm, "param1", "param2"})
     assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :clear}
 
-    refute_receive _
     Alarmist.remove_managed_alarm({IdentityTuple2Alarm, "param1", "param2"})
+    assert_receive %Alarmist.Event{id: {IdentityTuple2Alarm, "param1", "param2"}, state: :unknown}
+
+    Alarmist.unsubscribe({IdentityTuple2Alarm, :_, :_})
   end
 
   test "three parameter identity" do
     Alarmist.subscribe({IdentityTuple3Alarm, :_, :_, :_})
     Alarmist.add_managed_alarm({IdentityTuple3Alarm, "param1", "param2", "param3"})
-    refute_received _
+
+    assert_receive %Alarmist.Event{
+      id: {IdentityTuple3Alarm, "param1", "param2", "param3"},
+      state: :clear
+    }
 
     :alarm_handler.set_alarm({{IdentityTupleTriggerAlarm, "param1", "param2", "param3"}, nil})
 
@@ -121,7 +131,13 @@ defmodule Integration.ParameterizedTest do
       state: :clear
     }
 
-    refute_receive _
     Alarmist.remove_managed_alarm({IdentityTuple3Alarm, "param1", "param2", "param3"})
+
+    assert_receive %Alarmist.Event{
+      id: {IdentityTuple3Alarm, "param1", "param2", "param3"},
+      state: :unknown
+    }
+
+    Alarmist.unsubscribe({IdentityTuple3Alarm, :_, :_, :_})
   end
 end

--- a/test/integration/sustain_window_test.exs
+++ b/test/integration/sustain_window_test.exs
@@ -14,6 +14,7 @@ defmodule Integration.SustainWindowTest do
   test "basic case" do
     Alarmist.subscribe(SustainWindowAlarm)
     Alarmist.add_managed_alarm(SustainWindowAlarm)
+    assert_receive %Alarmist.Event{id: SustainWindowAlarm, state: :clear}
 
     # Alarm gets raised when >100ms in a 200ms period
     :alarm_handler.set_alarm({SustainWindowTriggerAlarm, "basic"})
@@ -34,6 +35,7 @@ defmodule Integration.SustainWindowTest do
   test "no trigger on accumulation" do
     Alarmist.subscribe(SustainWindowAlarm)
     Alarmist.add_managed_alarm(SustainWindowAlarm)
+    assert_receive %Alarmist.Event{id: SustainWindowAlarm, state: :clear}
 
     # Alarm gets raised when >100ms in a 200ms period
     Enum.each(1..6, fn i ->
@@ -53,6 +55,7 @@ defmodule Integration.SustainWindowTest do
   test "redundant sets are ignored" do
     Alarmist.subscribe(SustainWindowAlarm)
     Alarmist.add_managed_alarm(SustainWindowAlarm)
+    assert_receive %Alarmist.Event{id: SustainWindowAlarm, state: :clear}
 
     # The core implementation has an assumption that there are no
     # duplicate alarm notifications. If the duplicate clear alarms
@@ -74,6 +77,7 @@ defmodule Integration.SustainWindowTest do
   test "redundant clears are ignored" do
     Alarmist.subscribe(SustainWindowAlarm)
     Alarmist.add_managed_alarm(SustainWindowAlarm)
+    assert_receive %Alarmist.Event{id: SustainWindowAlarm, state: :clear}
 
     # The core implementation has an assumption that there are no
     # duplicate alarm notifications. If the duplicate clear alarms


### PR DESCRIPTION
This commit ensures event messages are always sent on alarm changes from
unknown -> clear and clear -> unknown. It also ensures that managed
alarms are always clear or set when they're actively being managed. This
results in more events being sent that previous, but this should be
welcome as it means that listeners will have more accurate state.

This fixes an issue where getting the state of a managed alarm could
return `:unknown` and the user would need to infer that it was `:clear`.
It was ok to do this since Alarmist internally did it. However, if you
did this, you couldn't tell if the managed alarm was never added or if
you mispelled the alarm ID. Now that managed alarms are always `:set` or
`:clear`, if you ever get `:unknown` back, you'll know that something is
wrong.
