### PR TITLE
Add `unknown_as_set/1` to catch initialization failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ These alarms could just be due to initialization order where the code that
 reports them hasn't run yet. They could also be due to an Alarm ID being
 misspelled.
 
-Managed alarms treat unknown alarms as cleared in `alarm_if` expressions.
+Managed alarms treat unknown alarms as cleared in `alarm_if` expressions. To
+change this behavior, call `unknown_as_set/1` on the alarm.
 
 Lastly, Alarmist transitions managed alarm IDs to the `:unknown` state in
 `Alarmist.remove_managed_alarm/1`. While it's not common for managed alarms to
@@ -193,15 +194,31 @@ special purpose operators. The following sections document each of these.
 ### Identity
 
 Specifying an `AlarmId` by itself creates a new alarm whose state mirrors the
-original one. In other words, it creates an alias and is useful for decoupling
-the naming of alarms between projects.
+original one. If the alarm state is unknown, the resulting alarm state is clear. It is useful for creating aliases that decouple alarm naming between
+projects.
 
 ```elixir
-defmodule IdenticalAlarm do
+defmodule AliasedAlarm do
   use Alarmist.Alarm
 
   alarm_if do
     SomeOtherAlarmName
+  end
+end
+```
+
+### Unknown as set
+
+The `unknown_as_set/1` function returns an alarm as set whenever its state is
+unknown. It is useful when the lack of an alarm being cleared indicates an
+initialization failure.
+
+```elixir
+defmodule AliasedAlarm2 do
+  use Alarmist.Alarm
+
+  alarm_if do
+    unknown_as_set(SomeOtherAlarmName)
   end
 end
 ```

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -86,6 +86,15 @@ defmodule Alarmist.Alarm do
   end
 
   @doc false
+  defmacro unknown_as_set(expression) do
+    expr_expanded = expand_expression(expression, __CALLER__)
+
+    quote bind_quoted: [expr_expanded: expr_expanded] do
+      [:unknown_as_set, expr_expanded]
+    end
+  end
+
+  @doc false
   defmacro debounce(expression, time) do
     expr_expanded = expand_expression(expression, __CALLER__)
 

--- a/lib/alarmist/ops.ex
+++ b/lib/alarmist/ops.ex
@@ -38,6 +38,32 @@ defmodule Alarmist.Ops do
   end
 
   @doc """
+  Return an alarm as set if it's unknown
+
+  All Alarmist operations except this one treat unknown alarms as cleared. Use
+  this to treat unknown alarms as set. This is useful for detecting initialization
+  failures where the code that should be setting or clearing the alarm doesn't
+  run.
+
+  Example:
+
+  ```elixir
+  defmodule NewAlarm do
+    use Alarmist.Alarm
+
+    alarm_if do
+      unknown_as_set(OriginalAlarm)
+    end
+  end
+  ```
+  """
+  @spec unknown_as_set(engine(), [Alarmist.alarm_id()]) :: engine()
+  def unknown_as_set(engine, [output, input]) do
+    {engine, {state, description}} = Engine.cache_get(engine, input, {:set, nil})
+    Engine.cache_put(engine, output, state, description)
+  end
+
+  @doc """
   Set an alarm when the input alarm is cleared
 
   This is useful for "proof-of-life" alarms where the presence of an alarm is a

--- a/test/alarmist/alarm_if_test.exs
+++ b/test/alarmist/alarm_if_test.exs
@@ -69,6 +69,25 @@ defmodule Alarmist.AlarmIfTest do
     assert ParameterizedIdentityTest2.__get_condition__() == expected_result
   end
 
+  test "unknown_as_set" do
+    defmodule UnknownAsSetTest do
+      use Alarmist.Alarm
+
+      alarm_if do
+        unknown_as_set(MyAlarmId)
+      end
+    end
+
+    expected_result = %{
+      rules: [{Alarmist.Ops, :unknown_as_set, [UnknownAsSetTest, MyAlarmId]}],
+      temporaries: [],
+      options: %{style: :atom, parameters: []}
+    }
+
+    assert UnknownAsSetTest.__get_condition__() == expected_result
+    assert UnknownAsSetTest.__get_condition_source__() == "unknown_as_set(MyAlarmId)"
+  end
+
   test "and" do
     defmodule AndTest do
       use Alarmist.Alarm

--- a/test/integration/unknown_as_set_test.exs
+++ b/test/integration/unknown_as_set_test.exs
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Integration.UnknownAsSetTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    on_exit(fn -> AlarmUtilities.assert_clean_state() end)
+  end
+
+  test "basic case" do
+    Alarmist.subscribe(UnknownAsSetAlarm)
+    Alarmist.add_managed_alarm(UnknownAsSetAlarm)
+
+    # Starts as set without any transient events
+    assert_receive %Alarmist.Event{id: UnknownAsSetAlarm, state: :set, previous_state: :unknown}
+    refute_received _
+
+    # Setting it does nothing
+    :alarm_handler.set_alarm({UnknownAsSetTriggerAlarm, nil})
+    refute_receive _, 50
+
+    # Clearing sends an event like normal
+    :alarm_handler.clear_alarm(UnknownAsSetTriggerAlarm)
+    assert_receive %Alarmist.Event{id: UnknownAsSetAlarm, state: :clear}
+
+    Alarmist.remove_managed_alarm(UnknownAsSetAlarm)
+    assert_receive %Alarmist.Event{id: UnknownAsSetAlarm, state: :unknown}
+    :alarm_handler.clear_alarm(UnknownAsSetAlarm)
+  end
+end

--- a/test/support/unknown_as_set_alarm.ex
+++ b/test/support/unknown_as_set_alarm.ex
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule UnknownAsSetAlarm do
+  use Alarmist.Alarm
+
+  alarm_if do
+    unknown_as_set(UnknownAsSetTriggerAlarm)
+  end
+end


### PR DESCRIPTION
Now that unknown alarm handling semantics are documented and checked,
there needs to be an easy way to assume that an alarm is set if its
unknown. This function handles that.
