### PR TITLE
Simplify creating simple remedies for alarms

### DIFF
--- a/lib/alarmist.ex
+++ b/lib/alarmist.ex
@@ -13,6 +13,7 @@ defmodule Alarmist do
   `Alarmist.Alarm`.
   """
   alias Alarmist.Handler
+  alias Alarmist.RemedySupervisor
 
   # SASL doesn't export types for these so create them here
   @typedoc """
@@ -101,6 +102,32 @@ defmodule Alarmist do
           sort: :level | :alarm_id | :duration,
           ansi_enabled?: boolean()
         ]
+
+  @typedoc """
+  Callback function for fixing alarms
+
+  This may be an MFA or function reference that takes zero or one
+  arguments. If it takes one argument, the alarm ID is passed.
+  """
+  @type remedy_fn() :: (-> any()) | (alarm_id() -> any()) | mfa()
+
+  @typedoc """
+  Options for running the remedy callback
+
+  * `:retry_timeout` — time to wait for the alarm to be cleared before calling the callback again (default: `:infinity`)
+  * `:callback_timeout` — time to wait for the callback to run (default: 60 seconds)
+  """
+  @type remedy_options() :: [
+          retry_timeout: timeout(),
+          callback_timeout: timeout()
+        ]
+
+  @typedoc """
+  Remedy callback with or without options
+
+  See `Alarmist.Alarm.__using__/1`
+  """
+  @type remedy() :: remedy_fn() | {remedy_fn(), remedy_options()}
 
   @doc """
   Subscribe to alarm status events
@@ -357,6 +384,60 @@ defmodule Alarmist do
   @spec managed_alarm_ids(timeout()) :: [alarm_id()]
   def managed_alarm_ids(timeout \\ 5000) do
     Handler.managed_alarm_ids(timeout)
+  end
+
+  @doc """
+  Add a callback to fix an Alarm ID
+
+  This is a simple way of adding a callback function to deal with an alarm
+  being set. Conceptually it is similar to starting a `GenServer`, calling
+  `subscribe/1`, and running the callback on alarm set messages. It provides a
+  number of conveniences:
+
+  * Supervision is handled for you. If the callback crashes, you'll get a
+    message in the log, but it won't prevent future attempts
+  * Handles fast toggling of alarm states to prevent the callback runs from
+    queuing or running concurrently
+  * Can repeatedly call the callback after a retry delay for alarms that aren't
+    clearing
+  * Times out hung callbacks to allow for future invocations without violating
+    the guarantee that only one callback is run for an alarm ID at any one time.
+
+  Only one remedy callback can be registered per alarm ID. If you are running
+  the remedy on a managed alarm, see `Alarmist.Alarm` for specifying it there
+  and the remedy callback will be automatically added when the managed alarm
+  is.
+
+  Options:
+  * `:retry_timeout` — time to wait for the alarm to be cleared before calling
+    the callback again (default: `:infinity`)
+  * `:callback_timeout` — time to wait for the callback to run (default: 60 seconds)
+
+  Since there can only be one remedy per Alarm ID, subsequent calls replace. If
+  an alarm is already set, the new callback will be called the next time. This
+  means that crash/restarts of the process that adds the remedy does not cause
+  the callback to be invoked twice. In fact, if the callback and options are
+  the same, it will look like a no-op. If you don't want this behavior, call
+  `remove_remedy/1` and then `add_remedy/3` to force new calls to be made.
+  """
+  @spec add_remedy(alarm_id(), remedy_fn(), remedy_options()) :: :ok | {:error, atom()}
+  def add_remedy(alarm_id, callback, options \\ []) do
+    RemedySupervisor.start_worker(alarm_id, {callback, options})
+  end
+
+  @doc """
+  Remove a remedy callback
+
+  If the callback is currently running, Alarmist brutally kills its worker
+  process.
+
+  There's generally no need to remove a remedy callback that's automatically
+  added as part of a managed alarm. Removing the managed alarm removes its
+  remedy.
+  """
+  @spec remove_remedy(alarm_id()) :: :ok | {:error, :not_found}
+  def remove_remedy(alarm_id) do
+    RemedySupervisor.stop_worker(alarm_id)
   end
 
   @doc """

--- a/lib/alarmist/alarm.ex
+++ b/lib/alarmist/alarm.ex
@@ -146,10 +146,13 @@ defmodule Alarmist.Alarm do
 
   * `:level` - the alarm severity. See `t:Logger.level/0`. Defaults to
     `:warning` and can be overridden by `Alarmist.set_alarm_level/2`.
-  * `:parameters` a list of atom keys that refine the scope of the alarm. For
+  * `:parameters` - a list of atom keys that refine the scope of the alarm. For
     example, a networking alarm might specify `[:ifname]` to indicate that the
     alarm pertains to a specific network interface.
-  * `:style` the alarm style when parameters are used. Defaults to
+  * `:remedy` - a function or a {function, options} tuple. The function is
+    called when the alarm is set. The function can either be a reference or MFA
+    taking 0 or 1 arguments. If 1-arity, it is passed the `alarm_id`.
+  * `:style` - the alarm style when parameters are used. Defaults to
     `:tagged_tuple` to indicate that alarms are tuples where the first element
     is the alarm type and the subsequent elements are the parameters.
   """
@@ -183,11 +186,14 @@ defmodule Alarmist.Alarm do
         :ok
     end
 
+    remedy = Keyword.get(options, :remedy)
+
     quote do
       @before_compile unquote(__MODULE__)
       @alarmist_level unquote(level)
-      @alarmist_style unquote(style)
       @alarmist_parameters unquote(parameters)
+      @alarmist_remedy unquote(remedy)
+      @alarmist_style unquote(style)
 
       Module.register_attribute(__MODULE__, :alarmist_alarm, [])
 
@@ -197,6 +203,12 @@ defmodule Alarmist.Alarm do
       @spec __alarm_level__() :: Logger.level()
       def __alarm_level__() do
         @alarmist_level
+      end
+
+      @doc false
+      @spec __remedy__() :: nil | Alarmist.remedy()
+      def __remedy__() do
+        @alarmist_remedy
       end
 
       def __alarm_parameters__(alarm_id) do

--- a/lib/alarmist/application.ex
+++ b/lib/alarmist/application.ex
@@ -16,6 +16,7 @@ defmodule Alarmist.Application do
        name: Alarmist,
        matcher: Alarmist.Matcher,
        event_transformer: &Alarmist.Event.from_property_table/1},
+      {Alarmist.RemedySupervisor, name: Alarmist.RemedySupervisor},
       {Task, &install_handler/0}
     ]
 

--- a/lib/alarmist/handler.ex
+++ b/lib/alarmist/handler.ex
@@ -11,6 +11,7 @@ defmodule Alarmist.Handler do
   import Alarmist, only: [is_alarm_id: 1]
 
   alias Alarmist.Engine
+  alias Alarmist.RemedySupervisor
 
   require Logger
 
@@ -233,6 +234,14 @@ defmodule Alarmist.Handler do
 
   defp run_side_effect({:forget, alarm_id}) do
     PropertyTable.delete(Alarmist, alarm_id)
+  end
+
+  defp run_side_effect({:register_remedy, alarm_id, remedy}) do
+    RemedySupervisor.start_worker(alarm_id, remedy)
+  end
+
+  defp run_side_effect({:unregister_remedy, alarm_id}) do
+    RemedySupervisor.stop_worker(alarm_id)
   end
 
   defp run_side_effect({:start_timer, alarm_id, timeout, what, params}) do

--- a/lib/alarmist/remedy_supervisor.ex
+++ b/lib/alarmist/remedy_supervisor.ex
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.RemedySupervisor do
+  @moduledoc false
+  use Supervisor
+
+  alias Alarmist.RemedyWorker
+
+  @spec start_link(Keyword.t()) :: Supervisor.on_start()
+  def start_link(options) do
+    Supervisor.start_link(__MODULE__, options, name: options[:name] || __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(_options) do
+    children = [
+      {Registry, keys: :unique, name: Alarmist.Remedy.Registry},
+      {Task.Supervisor, name: Alarmist.Remedy.TaskSupervisor},
+      {DynamicSupervisor, name: Alarmist.Remedy.DynamicSupervisor, strategy: :one_for_one}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  @spec start_worker(Alarmist.alarm_id(), Alarmist.remedy()) :: :ok | {:error, atom()}
+  def start_worker(alarm_id, remedy) do
+    options =
+      [
+        alarm_id: alarm_id,
+        remedy: remedy,
+        task_supervisor: Alarmist.Remedy.TaskSupervisor
+      ]
+
+    case DynamicSupervisor.start_child(
+           Alarmist.Remedy.DynamicSupervisor,
+           {Alarmist.RemedyWorker, options}
+         ) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, pid}} -> RemedyWorker.configure(pid, remedy)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec stop_worker(Alarmist.alarm_id()) :: :ok | {:error, :not_found}
+  def stop_worker(alarm_id) do
+    RemedyWorker.stop(alarm_id)
+  end
+end

--- a/lib/alarmist/remedy_worker.ex
+++ b/lib/alarmist/remedy_worker.ex
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.RemedyWorker do
+  @moduledoc """
+  Remedy callback runner
+
+  This module handles the common concerns with running the code that
+  fixes alarms. Users don't call this module directly, but how it
+  works can be useful. Callbacks should be registered in a module
+  that has `use Alarmist.Alarm` or by calling `Alarmist.add_remedy/2`.
+
+  You can think of this module as a supervised `GenServer` that listens
+  for an Alarm ID and runs a callback function when it's set. It has
+  a few more features, though:
+
+  1. If the alarm toggles back and forth while a callback is running, the
+     events don't queue. The callback is run to completion.
+  2. A timer can be set on the callback to kill the process if it hangs.
+  3. If the alarm persists, the callback can be called again after a
+     configurable retry timeout.
+
+  One would hope to not need any of these features. Alarms usually don't
+  happen under normal operation, though, so some additional bulletproofing
+  can be nice.
+
+  The following options control the handling:
+
+  * `:retry_timeout` — time to wait for the alarm to be cleared before calling the callback again (default: `:infinity`)
+  * `:callback_timeout` — time to wait for the callback to run (default: 60 seconds)
+
+  Since the `:retry_timeout` defaults to `:infinity`, the callback is only called when
+  the alarm gets set or if the `RemedyWorker` gets restarted.
+
+  ## State Machine Diagram
+
+  ```mermaid
+  stateDiagram-v2
+    [*] --> clear : initial state
+
+    clear --> running : alarm set
+
+    running --> finishing_run : alarm cleared
+    running --> waiting_to_retry : callback completes or times out
+
+    waiting_to_retry --> running : retry delay timer expires
+    waiting_to_retry --> clear : alarm cleared
+
+    finishing_run --> clear : callback completes or timeouts
+    finishing_run --> running : alarm set
+  ```
+  """
+  @behaviour :gen_statem
+
+  require Logger
+
+  @default_retry_timeout :infinity
+  @default_callback_timeout :timer.seconds(60)
+
+  @default_options [
+    retry_timeout: @default_retry_timeout,
+    callback_timeout: @default_callback_timeout
+  ]
+  @remedy_options Keyword.keys(@default_options)
+
+  @typep state_name() :: :clear | :running | :waiting_to_retry | :finishing_run
+  @typep data() :: %{
+           alarm_id: Alarmist.alarm_id(),
+           task_supervisor: module(),
+           task: Task.t() | nil,
+           raw_callback: Alarmist.remedy_fn(),
+           callback: (-> any()),
+           retry_timeout: timeout(),
+           callback_timeout: timeout()
+         }
+
+  @doc false
+  @spec via(Alarmist.alarm_id()) ::
+          {:via, Registry, {Alarmist.Remedy.Registry, Alarmist.alarm_id()}}
+  def via(alarm_id), do: {:via, Registry, {Alarmist.Remedy.Registry, alarm_id}}
+
+  @doc false
+  @spec child_spec(Keyword.t()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    alarm_id = Keyword.fetch!(opts, :alarm_id)
+
+    %{
+      id: {__MODULE__, alarm_id},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient,
+      shutdown: 5_000,
+      type: :worker
+    }
+  end
+
+  @doc """
+  Start the remedy worker
+
+  Options:
+  * `:alarm_id` — Alarm ID that the callback remedies (required)
+  * `:task_supervisor` — name or pid of Task.Supervisor
+  * `:remedy` — see `Alarmist.Alarm.__using__/1`
+  """
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts) do
+    # Add `debug: [:trace]` for verbose state machine logging
+    :gen_statem.start_link(via(Keyword.fetch!(opts, :alarm_id)), __MODULE__, opts, [])
+  end
+
+  @doc """
+  Stop a worker
+
+  If the worker is in the process of calling a callback, it will kill the callback process
+  too.
+  """
+  @spec stop(Alarmist.alarm_id()) :: :ok | {:error, :not_found}
+  def stop(alarm_id) do
+    :gen_statem.stop(via(alarm_id), :normal, 5000)
+  catch
+    :exit, :noproc -> {:error, :not_found}
+  end
+
+  @doc false
+  @spec configure(pid(), Alarmist.remedy()) :: :ok | {:error, :not_found}
+  def configure(pid, remedy) do
+    :gen_statem.call(pid, {:configure, remedy})
+  catch
+    :exit, :noproc -> {:error, :not_found}
+  end
+
+  @impl :gen_statem
+  def callback_mode(), do: [:state_functions, :state_enter]
+
+  @impl :gen_statem
+  def init(opts) do
+    alarm_id = Keyword.fetch!(opts, :alarm_id)
+
+    initial_status = Alarmist.alarm_state(alarm_id)
+    Alarmist.subscribe(alarm_id)
+
+    {raw_callback, callback_opts} = Keyword.fetch!(opts, :remedy) |> normalize_remedy()
+    callback = remedy_fun(alarm_id, raw_callback)
+
+    data = %{
+      alarm_id: alarm_id,
+      callback: callback,
+      raw_callback: raw_callback,
+      callback_timeout: Keyword.get(callback_opts, :callback_timeout),
+      retry_timeout: Keyword.get(callback_opts, :retry_timeout),
+      task: nil,
+      task_supervisor: Keyword.get(opts, :task_supervisor, Alarmist.Remedy.TaskSupervisor)
+    }
+
+    {:ok, :clear, data, [{:next_event, :info, %Alarmist.Event{state: initial_status}}]}
+  end
+
+  @impl :gen_statem
+  def terminate(_reason, _currentState, data) do
+    if data.task != nil do
+      Task.shutdown(data.task, :brutal_kill)
+    end
+  end
+
+  # ——— State: :clear ———————————————————————————————————————————————
+
+  @doc false
+  @spec clear(:enter, state_name(), data()) :: any()
+  @spec clear(:gen_statem.event_type(), any(), data()) :: any()
+  def clear(:enter, _previous_state, _data), do: :keep_state_and_data
+  def clear(:info, %Alarmist.Event{state: :set}, data), do: {:next_state, :running, data}
+  def clear(:info, %Alarmist.Event{}, _data), do: :keep_state_and_data
+
+  def clear({:call, from}, {:configure, opts}, data) do
+    {new_data, _changed} = refresh_data(data, opts)
+    {:keep_state, new_data, [{:reply, from, :ok}]}
+  end
+
+  # ——— State: :waiting_to_retry ————————————————————————————————————————
+
+  @doc false
+  @spec waiting_to_retry(:enter, state_name(), data()) :: any()
+  @spec waiting_to_retry(:gen_statem.event_type(), any(), data()) :: any()
+
+  def waiting_to_retry(:enter, _previous_state, data),
+    do: {:keep_state_and_data, [{{:timeout, :retry}, data.retry_timeout, :timeout}]}
+
+  def waiting_to_retry({:timeout, :retry}, :timeout, data),
+    do: {:next_state, :running, data, []}
+
+  def waiting_to_retry(:info, %Alarmist.Event{state: :clear}, data),
+    do: {:next_state, :clear, data, [{{:timeout, :retry}, :cancel}]}
+
+  def waiting_to_retry({:call, from}, {:configure, remedy}, data) do
+    {new_data, changed} = refresh_data(data, remedy)
+
+    actions =
+      if :retry_timeout in changed,
+        do: [{{:timeout, :retry}, new_data.retry_timeout, :timeout}],
+        else: []
+
+    {:keep_state, new_data, [{:reply, from, :ok} | actions]}
+  end
+
+  def waiting_to_retry(_type, _msg, _data), do: :keep_state_and_data
+
+  # ——— State: :running ———————————————————————————————————————————————
+
+  # Special case when a clear and set happens before a remedy completes.
+  # Handle this by ignoring that the glitch ever happened.
+  @doc false
+  @spec running(:enter, state_name(), data()) :: any()
+  @spec running(:gen_statem.event_type(), any(), data()) :: any()
+  def running(:enter, :finishing_run, _data), do: :keep_state_and_data
+
+  # Start the remedy callback running
+  def running(:enter, _previous_state, data) do
+    task = Task.Supervisor.async_nolink(data.task_supervisor, data.callback)
+
+    {:keep_state, %{data | task: task}, [{{:timeout, :run}, data.callback_timeout, :timeout}]}
+  end
+
+  def running(:info, %Alarmist.Event{state: :clear}, data),
+    do: {:next_state, :finishing_run, data, []}
+
+  def running(:info, {ref, _result}, %{task: %{ref: ref}} = data) do
+    Process.demonitor(ref, [:flush])
+
+    {:next_state, :waiting_to_retry, %{data | task: nil}, [{{:timeout, :run}, :cancel}]}
+  end
+
+  def running(:info, {:DOWN, ref, :process, _pid, _reason}, %{task: %{ref: ref}} = data) do
+    {:next_state, :waiting_to_retry, %{data | task: nil}, [{{:timeout, :run}, :cancel}]}
+  end
+
+  def running({:timeout, :run}, :timeout, data) do
+    Logger.error(
+      "Remedy callback for alarm #{inspect(data.alarm_id)} timed out after #{data.callback_timeout}ms"
+    )
+
+    _ = Task.shutdown(data.task, :brutal_kill)
+
+    {:next_state, :waiting_to_retry, %{data | task: nil}, []}
+  end
+
+  def running({:call, from}, {:configure, opts}, data) do
+    {new_data, changed} = refresh_data(data, opts)
+
+    actions =
+      if :callback_timeout in changed,
+        do: [{{:timeout, :run}, new_data.callback_timeout, :timeout}],
+        else: []
+
+    {:keep_state, new_data, [{:reply, from, :ok} | actions]}
+  end
+
+  def running(_type, _msg, _data), do: :keep_state_and_data
+
+  # ——— State: :finishing_run ————————————————————————————————————————
+
+  @doc false
+  @spec finishing_run(:gen_statem.event_type(), any(), data()) :: any()
+  def finishing_run(:info, {ref, _result}, %{task: %{ref: ref}} = data) do
+    Process.demonitor(ref, [:flush])
+
+    {:next_state, :clear, %{data | task: nil}, [{{:timeout, :run}, :cancel}]}
+  end
+
+  def finishing_run(:info, {:DOWN, ref, :process, _pid, _reason}, %{task: %{ref: ref}} = data) do
+    {:next_state, :clear, %{data | task: nil}, [{{:timeout, :run}, :cancel}]}
+  end
+
+  def finishing_run({:timeout, :run}, :timeout, data) do
+    Logger.error(
+      "Remedy callback for alarm #{inspect(data.alarm_id)} timed out after #{data.callback_timeout}ms, but alarm is clear now anyway."
+    )
+
+    _ = Task.shutdown(data.task, :brutal_kill)
+
+    {:next_state, :clear, %{data | task: nil}}
+  end
+
+  def finishing_run(:info, %Alarmist.Event{state: :set}, data) do
+    # set->clear->set glitch
+    {:next_state, :running, data}
+  end
+
+  def finishing_run({:call, from}, {:configure, opts}, data) do
+    {new_data, changed} = refresh_data(data, opts)
+
+    actions =
+      if :callback_timeout in changed,
+        do: [{{:timeout, :run}, new_data.callback_timeout, :timeout}],
+        else: []
+
+    {:keep_state, new_data, [{:reply, from, :ok} | actions]}
+  end
+
+  def finishing_run(_type, _msg, _data), do: :keep_state_and_data
+
+  defp refresh_data(data, new_remedy) do
+    {raw_callback, new_opts} = normalize_remedy(new_remedy)
+
+    acc = update_on_change({:raw_callback, raw_callback}, {data, []})
+
+    Enum.reduce(new_opts, acc, &update_on_change/2)
+  end
+
+  defp update_on_change({:raw_callback, v}, {data, changed}) do
+    if v != data.raw_callback do
+      new_data = %{data | raw_callback: v, callback: remedy_fun(data.alarm_id, v)}
+      {new_data, [:callback | changed]}
+    else
+      {data, changed}
+    end
+  end
+
+  defp update_on_change({k, v}, {data, changed}) do
+    if v != data[k] do
+      {Map.put(data, k, v), [k | changed]}
+    else
+      {data, changed}
+    end
+  end
+
+  defp normalize_remedy({callback, opts}),
+    do: {callback, Keyword.merge(@default_options, Keyword.take(opts, @remedy_options))}
+
+  defp normalize_remedy(callback), do: {callback, @default_options}
+
+  # Normalize all the ways of specifying a remedy callback into a simple
+  # 0-arity function for Task.
+  defp remedy_fun(_alarm_id, {m, f, 0}), do: Function.capture(m, f, 0)
+  defp remedy_fun(alarm_id, {m, f, 1}), do: fn -> apply(m, f, [alarm_id]) end
+  defp remedy_fun(_alarm_id, f) when is_function(f, 0), do: f
+  defp remedy_fun(alarm_id, f) when is_function(f, 1), do: fn -> f.(alarm_id) end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,7 @@ defmodule Alarmist.MixProject do
 
   defp docs do
     [
+      before_closing_body_tag: &before_closing_body_tag/1,
       extras: ["README.md", "CHANGELOG.md"],
       main: "readme",
       source_ref: "v#{@version}",
@@ -90,4 +91,39 @@ defmodule Alarmist.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
     ]
   end
+
+  defp before_closing_body_tag(:html) do
+    """
+    <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10.2.3/dist/mermaid.min.js"></script>
+    <script>
+      let initialized = false;
+
+      window.addEventListener("exdoc:loaded", () => {
+        if (!initialized) {
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: document.body.className.includes("dark") ? "dark" : "default"
+          });
+          initialized = true;
+        }
+
+        let id = 0;
+        for (const codeEl of document.querySelectorAll("pre code.mermaid")) {
+          const preEl = codeEl.parentElement;
+          const graphDefinition = codeEl.textContent;
+          const graphEl = document.createElement("div");
+          const graphId = "mermaid-graph-" + id++;
+          mermaid.render(graphId, graphDefinition).then(({svg, bindFunctions}) => {
+            graphEl.innerHTML = svg;
+            bindFunctions?.(graphEl);
+            preEl.insertAdjacentElement("afterend", graphEl);
+            preEl.remove();
+          });
+        }
+      });
+    </script>
+    """
+  end
+
+  defp before_closing_body_tag(_), do: ""
 end

--- a/test/alarmist/remedy_worker_test.exs
+++ b/test/alarmist/remedy_worker_test.exs
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Alarmist.RemedyWorkerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Alarmist.RemedyWorker
+
+  @alarm_id :test_remedy_alarm
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    on_exit(fn -> AlarmUtilities.assert_clean_state() end)
+
+    :ok
+  end
+
+  defp start_worker(remedy) do
+    opts = [
+      alarm_id: @alarm_id,
+      task_supervisor: Alarmist.Remedy.TaskSupervisor,
+      remedy: remedy
+    ]
+
+    _ = start_supervised!({RemedyWorker, opts})
+    :ok
+  end
+
+  defp quick_remedy_callback() do
+    pid = self()
+
+    fn alarm_id ->
+      send(pid, {:callback_finished, alarm_id})
+      :ok
+    end
+  end
+
+  defp slow_remedy_callback(delay) do
+    pid = self()
+
+    fn alarm_id ->
+      send(pid, {:callback_started, alarm_id})
+      Process.sleep(delay)
+      send(pid, {:callback_finished, alarm_id})
+      :ok
+    end
+  end
+
+  defp crashing_remedy_callback() do
+    pid = self()
+
+    fn alarm_id ->
+      send(pid, {:callback_started, alarm_id})
+      raise "oops"
+    end
+  end
+
+  test "executes callback when alarm gets set" do
+    start_worker(quick_remedy_callback())
+    refute_receive _
+
+    :alarm_handler.set_alarm({@alarm_id, nil})
+    assert_receive {:callback_finished, @alarm_id}
+
+    :alarm_handler.clear_alarm(@alarm_id)
+  end
+
+  test "executes callback when alarm is already set" do
+    :alarm_handler.set_alarm({@alarm_id, nil})
+
+    start_worker(quick_remedy_callback())
+
+    assert_receive {:callback_finished, @alarm_id}
+
+    :alarm_handler.clear_alarm(@alarm_id)
+  end
+
+  test "allows callback to finish when alarm cleared midway" do
+    start_worker(slow_remedy_callback(100))
+
+    :alarm_handler.set_alarm({@alarm_id, nil})
+    assert_receive {:callback_started, @alarm_id}
+
+    :alarm_handler.clear_alarm(@alarm_id)
+    refute_receive _, 50
+
+    assert_receive {:callback_finished, @alarm_id}, 100
+    refute_receive _, 50
+  end
+
+  test "transient clear and set does not run callback twice" do
+    # This ensures that a remedy is run to completion even if a transient
+    # happens. I.e., no killing processes or double callback calls
+    start_worker(slow_remedy_callback(100))
+
+    :alarm_handler.set_alarm({@alarm_id, 1})
+    assert_receive {:callback_started, @alarm_id}
+
+    :alarm_handler.clear_alarm(@alarm_id)
+    :alarm_handler.set_alarm({@alarm_id, 2})
+    refute_receive _, 50
+
+    assert_receive {:callback_finished, @alarm_id}, 100
+    refute_receive _
+    :alarm_handler.clear_alarm(@alarm_id)
+  end
+
+  test "crashing callback logged and retried" do
+    start_worker({crashing_remedy_callback(), retry_timeout: 100})
+
+    result =
+      capture_log(fn ->
+        :alarm_handler.set_alarm({@alarm_id, nil})
+        assert_receive {:callback_started, @alarm_id}
+        refute_receive _, 50
+
+        # Retry should happen in ~50ms
+        assert_receive {:callback_started, @alarm_id}, 100
+
+        :alarm_handler.clear_alarm(@alarm_id)
+        refute_receive _, 50
+      end)
+
+    runtime_error_count =
+      result |> String.split("\n") |> Enum.count(&String.contains?(&1, "(RuntimeError) oops"))
+
+    assert runtime_error_count == 2
+  end
+
+  test "hung callback logged and retried" do
+    start_worker({slow_remedy_callback(1000), callback_timeout: 50, retry_timeout: 100})
+
+    result =
+      capture_log(fn ->
+        :alarm_handler.set_alarm({@alarm_id, nil})
+        assert_receive {:callback_started, @alarm_id}
+        refute_receive _, 75
+
+        # Check for retry in 100ms
+        assert_receive {:callback_started, @alarm_id}, 150
+
+        # Clear and check for no retry
+        :alarm_handler.clear_alarm(@alarm_id)
+        refute_receive _, 200
+      end)
+
+    assert result =~ "Remedy callback for alarm :test_remedy_alarm timed out after 50ms"
+  end
+
+  test "hung callback logged with transients" do
+    # This exercises callback timeouts in the :finishing_run state rather than the
+    # :running state.
+    start_worker({slow_remedy_callback(1000), callback_timeout: 50})
+
+    result =
+      capture_log(fn ->
+        :alarm_handler.set_alarm({@alarm_id, nil})
+        assert_receive {:callback_started, @alarm_id}
+        :alarm_handler.clear_alarm(@alarm_id)
+        refute_receive _, 100
+
+        # Check that next alarm works (this is the important part)
+        :alarm_handler.set_alarm({@alarm_id, nil})
+        assert_receive {:callback_started, @alarm_id}
+      end)
+
+    assert result =~
+             "Remedy callback for alarm :test_remedy_alarm timed out after 50ms, but alarm is clear now anyway."
+
+    :alarm_handler.clear_alarm(@alarm_id)
+  end
+end

--- a/test/alarmist_test.exs
+++ b/test/alarmist_test.exs
@@ -568,4 +568,159 @@ defmodule AlarmistTest do
     assert_raise ArgumentError, fn -> Alarmist.alarm_type({"string", 1}) end
     assert_raise ArgumentError, fn -> Alarmist.alarm_type(%{}) end
   end
+
+  describe "Alarmist.add_remedy/3" do
+    test "basics" do
+      pid = self()
+      Alarmist.subscribe(:some_alarm)
+      Alarmist.add_remedy(:some_alarm, fn -> send(pid, :got_it) end)
+      refute_received _
+
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive %Alarmist.Event{id: :some_alarm, state: :set}
+      assert_receive :got_it
+
+      :alarm_handler.clear_alarm(:some_alarm)
+      assert_receive %Alarmist.Event{id: :some_alarm, state: :clear}
+      refute_receive _
+
+      Alarmist.unsubscribe(:some_alarm)
+      Alarmist.remove_remedy(:some_alarm)
+    end
+
+    test "add twice is ok" do
+      assert :ok = Alarmist.add_remedy(:some_alarm, &Function.identity/1)
+      assert :ok = Alarmist.add_remedy(:some_alarm, &Function.identity/1)
+    end
+
+    test "second add replaces" do
+      pid = self()
+      Alarmist.add_remedy(:some_alarm, fn _ -> send(pid, :no) end)
+      Alarmist.add_remedy(:some_alarm, fn _ -> send(pid, :yes) end)
+
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive :yes
+      :alarm_handler.clear_alarm(:some_alarm)
+    end
+
+    test "second add can change the retry timer" do
+      pid = self()
+      callback = fn _ -> send(pid, :callback_run) end
+
+      Alarmist.add_remedy(:some_alarm, callback)
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive :callback_run
+      refute_receive _
+
+      Alarmist.add_remedy(:some_alarm, callback, retry_timeout: 50)
+      assert_receive :callback_run
+      assert_receive :callback_run
+
+      :alarm_handler.clear_alarm(:some_alarm)
+      Alarmist.remove_remedy(:some_alarm)
+    end
+
+    test "second add with defaults uses the defaults" do
+      pid = self()
+      callback = fn _ -> send(pid, :callback_run) end
+
+      Alarmist.add_remedy(:some_alarm, callback, retry_timeout: 50)
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive :callback_run
+      refute_received _
+
+      # The default retry timeout is :infinity, so there should be no retries
+      # after adding the remedy again since it would have already run it.
+      Alarmist.add_remedy(:some_alarm, callback)
+      refute_receive _
+
+      :alarm_handler.clear_alarm(:some_alarm)
+      Alarmist.remove_remedy(:some_alarm)
+    end
+
+    test "second add can change the callback timer" do
+      pid = self()
+
+      callback = fn _ ->
+        send(pid, :started)
+        Process.sleep(100)
+        send(pid, :finished)
+      end
+
+      Alarmist.add_remedy(:some_alarm, callback, callback_timeout: 50, retry_timeout: 50)
+      :alarm_handler.set_alarm({:some_alarm, nil})
+
+      capture_log(fn ->
+        # Check that it was retried and never got to finish
+        assert_receive :started
+        refute_receive _, 50
+        assert_receive :started
+        refute_received _
+
+        # Lengthen the callback timeout so the 100ms sleep can finish
+        # now. There will be now `:started` since the config change should
+        # only update the timer.
+        Alarmist.add_remedy(:some_alarm, callback, callback_timeout: 200)
+        assert_receive :finished, 200
+        refute_received _
+      end)
+
+      :alarm_handler.clear_alarm(:some_alarm)
+      Alarmist.remove_remedy(:some_alarm)
+    end
+
+    test "mfa callbacks work" do
+      alarm_id = {:some_alarm, self()}
+
+      Alarmist.add_remedy(alarm_id, {__MODULE__, :test_remedy_callback, 1})
+      refute_received _
+
+      :alarm_handler.set_alarm({alarm_id, nil})
+      assert_receive :got_it
+
+      :alarm_handler.clear_alarm(alarm_id)
+      refute_receive _
+    end
+
+    def test_remedy_callback({:some_alarm, pid}) do
+      send(pid, :got_it)
+    end
+  end
+
+  describe "Alarmist.remove_remedy/3" do
+    test "remove removes" do
+      pid = self()
+      Alarmist.add_remedy(:some_alarm, fn _ -> send(pid, :hello) end)
+
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive :hello
+      :alarm_handler.clear_alarm(:some_alarm)
+
+      Alarmist.remove_remedy(:some_alarm)
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      refute_receive _
+      :alarm_handler.clear_alarm(:some_alarm)
+    end
+
+    test "removing unknown returns error" do
+      assert {:error, :not_found} == Alarmist.remove_remedy(:no_remedy_here)
+    end
+
+    test "removing running callback kills it" do
+      pid = self()
+
+      Alarmist.add_remedy(:some_alarm, fn _ ->
+        send(pid, :started)
+        Process.sleep(100)
+        send(pid, :finished)
+      end)
+
+      :alarm_handler.set_alarm({:some_alarm, nil})
+      assert_receive :started
+      assert :ok = Alarmist.remove_remedy(:some_alarm)
+
+      refute_receive _, 200
+      :alarm_handler.clear_alarm(:some_alarm)
+    end
+  end
 end

--- a/test/integration/remedy_test.exs
+++ b/test/integration/remedy_test.exs
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Integration.RemedyTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  setup do
+    AlarmUtilities.cleanup()
+
+    test_pid = self()
+    :persistent_term.put(:remedy_test_pid, test_pid)
+
+    on_exit(fn ->
+      :persistent_term.erase(:remedy_test_pid)
+      AlarmUtilities.assert_clean_state()
+    end)
+  end
+
+  test "colocated alarm remedy callback runs when alarm is set" do
+    Alarmist.subscribe({RemedyAlarm, :_})
+    Alarmist.add_managed_alarm({RemedyAlarm, "eth0"})
+    Alarmist.add_managed_alarm({RemedyAlarm, "wlan0"})
+    assert_receive %Alarmist.Event{id: {RemedyAlarm, "eth0"}, state: :clear}
+    assert_receive %Alarmist.Event{id: {RemedyAlarm, "wlan0"}, state: :clear}
+
+    :alarm_handler.set_alarm({{RemedyTriggerAlarm, "eth0"}, nil})
+    assert_receive %Alarmist.Event{id: {RemedyAlarm, "eth0"}, state: :set}
+    assert_receive {:remedy_callback_finished, {RemedyAlarm, "eth0"}}
+
+    :alarm_handler.clear_alarm({RemedyTriggerAlarm, "eth0"})
+    assert_receive %Alarmist.Event{id: {RemedyAlarm, "eth0"}, state: :clear}
+    refute_receive _
+
+    Alarmist.remove_managed_alarm({RemedyAlarm, "eth0"})
+    Alarmist.remove_managed_alarm({RemedyAlarm, "wlan0"})
+  end
+
+  test "sleeping remedy times out" do
+    Alarmist.subscribe({SleepingRemedyAlarm, 500})
+    Alarmist.add_managed_alarm({SleepingRemedyAlarm, 500})
+    assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 500}, state: :clear}
+
+    results =
+      capture_log(fn ->
+        :alarm_handler.set_alarm({{RemedyTriggerAlarm, 500}, nil})
+        assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 500}, state: :set}
+
+        # It should start immediately
+        assert_receive {:remedy_callback_started, {SleepingRemedyAlarm, 500}}
+
+        # It sleeps so long that it will time out and we should get another start ~200 ms
+        refute_receive _, 150
+
+        assert_receive {:remedy_callback_started, {SleepingRemedyAlarm, 500}}
+
+        :alarm_handler.clear_alarm({RemedyTriggerAlarm, 500})
+        assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 500}, state: :clear}
+        refute_receive _
+      end)
+
+    assert results =~ "Remedy callback for alarm {SleepingRemedyAlarm, 500} timed out"
+    Alarmist.remove_managed_alarm({SleepingRemedyAlarm, 500})
+  end
+
+  test "repeating remedy repeats" do
+    Alarmist.subscribe({SleepingRemedyAlarm, 5})
+    Alarmist.add_managed_alarm({SleepingRemedyAlarm, 5})
+    assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 5}, state: :clear}
+
+    :alarm_handler.set_alarm({{RemedyTriggerAlarm, 5}, nil})
+    assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 5}, state: :set}
+
+    # It should run immediately
+    assert_receive {:remedy_callback_started, {SleepingRemedyAlarm, 5}}
+    assert_receive {:remedy_callback_finished, {SleepingRemedyAlarm, 5}}
+
+    # Wait for the next start
+    refute_receive _, 150
+
+    assert_receive {:remedy_callback_started, {SleepingRemedyAlarm, 5}}
+    assert_receive {:remedy_callback_finished, {SleepingRemedyAlarm, 5}}
+
+    :alarm_handler.clear_alarm({RemedyTriggerAlarm, 5})
+    assert_receive %Alarmist.Event{id: {SleepingRemedyAlarm, 5}, state: :clear}
+    refute_receive _
+    Alarmist.remove_managed_alarm({SleepingRemedyAlarm, 5})
+  end
+end

--- a/test/support/remedy_alarms.ex
+++ b/test/support/remedy_alarms.ex
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 SmartRent Technologies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule RemedyAlarm do
+  use Alarmist.Alarm,
+    style: :tagged_tuple,
+    parameters: [:parameter1],
+    remedy: {__MODULE__, :remedy, 1}
+
+  alarm_if do
+    {RemedyTriggerAlarm, parameter1}
+  end
+
+  def remedy(alarm_id) do
+    send(:persistent_term.get(:remedy_test_pid), {:remedy_callback_finished, alarm_id})
+  end
+end
+
+defmodule SleepingRemedyAlarm do
+  use Alarmist.Alarm,
+    style: :tagged_tuple,
+    parameters: [:parameter1],
+    remedy: {{__MODULE__, :remedy, 1}, retry_timeout: 150, callback_timeout: 50}
+
+  alarm_if do
+    {RemedyTriggerAlarm, parameter1}
+  end
+
+  def remedy({SleepingRemedyAlarm, timeout} = alarm_id) do
+    pid = :persistent_term.get(:remedy_test_pid)
+    send(pid, {:remedy_callback_started, alarm_id})
+    Process.sleep(timeout)
+    send(pid, {:remedy_callback_finished, alarm_id})
+  end
+end


### PR DESCRIPTION
This adds support for calling a function when an alarm is set. That
function can be included when creating a managed alarm via `use
Alarmist.Alarm` options or by calling `Alarmist.add_remedy/3`.

This means that you no longer have to create a `GenServer` to listen for
alarm set events if you don't have a convenient one already. Alarmist
also helps by retrying remedies if they don't work and avoiding
unhelpful repeated work when the alarm status flaps repeatedly due to
instability.
