### PR TITLE
Revise the `hold/3` operation, addressing unexpected behavior in #75

### DIFF
--- a/test/integration/hold_test.exs
+++ b/test/integration/hold_test.exs
@@ -11,7 +11,7 @@ defmodule Integration.HoldTest do
     on_exit(fn -> AlarmUtilities.assert_clean_state() end)
   end
 
-  test "hold rules" do
+  test "holds out immediately cleared alarm" do
     Alarmist.subscribe(HoldAlarm)
     Alarmist.subscribe(HoldTriggerAlarm)
     Alarmist.add_managed_alarm(HoldAlarm)
@@ -24,9 +24,55 @@ defmodule Integration.HoldTest do
     :alarm_handler.clear_alarm(HoldTriggerAlarm)
     assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :clear, previous_state: :set}
 
-    refute_receive _
+    refute_receive _, 100
 
     assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear, previous_state: :set}, 250
+
+    Alarmist.remove_managed_alarm(HoldAlarm)
+  end
+
+  test "clear alarm that has been held long enough" do
+    Alarmist.subscribe(HoldAlarm)
+    Alarmist.subscribe(HoldTriggerAlarm)
+    Alarmist.add_managed_alarm(HoldAlarm)
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear}
+
+    :alarm_handler.set_alarm({HoldTriggerAlarm, nil})
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :set, description: nil}
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :set, description: nil}
+
+    refute_receive _, 300
+
+    :alarm_handler.clear_alarm(HoldTriggerAlarm)
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :clear, previous_state: :set}, 10
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear, previous_state: :set}, 10
+
+    Alarmist.remove_managed_alarm(HoldAlarm)
+  end
+
+  test "holds out unaffected by description changes" do
+    Alarmist.subscribe(HoldAlarm)
+    Alarmist.subscribe(HoldTriggerAlarm)
+    Alarmist.add_managed_alarm(HoldAlarm)
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear}
+
+    :alarm_handler.set_alarm({HoldTriggerAlarm, :description1})
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :set, description: :description1}
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :set, description: :description1}
+
+    refute_receive _, 100
+
+    :alarm_handler.set_alarm({HoldTriggerAlarm, :description2})
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :set, description: :description2}
+    # No event for HoldAlarm since redundant sets aren't passed through
+    refute_receive _, 10
+
+    :alarm_handler.clear_alarm(HoldTriggerAlarm)
+    assert_receive %Alarmist.Event{id: HoldTriggerAlarm, state: :clear, previous_state: :set}
+
+    refute_receive _, 100
+
+    assert_receive %Alarmist.Event{id: HoldAlarm, state: :clear, previous_state: :set}, 100
 
     Alarmist.remove_managed_alarm(HoldAlarm)
   end


### PR DESCRIPTION
* Addresses issue #75
* When using the `hold` operation, we will no longer set a clear timer right away.
* We will wait for the input alarm to enter the `:clear` state first, then, based on the amount of time the output alarm has already been set, we create the timer to clear the output alarm.
* If the input alarm is set again, we cancel the clear timer and start the process all over again.
* This results in predictable behaviors when using the `hold` operation.
* This PR also adds an additional test that mirrors the one provided in issue #75