### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Alarmist
 
 [![Hex version](https://img.shields.io/hexpm/v/alarmist.svg "Hex version")](https://hex.pm/packages/alarmist)
-[![API docs](https://img.shields.io/hexpm/v/alarmist.svg?label=hexdocs "API docs")](https://hexdocs.pm/alarmist/Alarmist.html)
+[![API docs](https://img.shields.io/hexpm/v/alarmist.svg?label=hexdocs "API docs")](https://alarmist.hexdocs.pm/Alarmist.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/alarmist/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/alarmist/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/alarmist)](https://api.reuse.software/info/github.com/nerves-project/alarmist)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://alarmist.hexdocs.pm/Alarmist.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>