### PR TITLE
Update Elixir 1.17 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ tags: &tags
     1.20.0-erlang-29.0.1-alpine-3.23.4,
     1.19.5-erlang-28.5.0.1-alpine-3.23.4,
     1.18.4-erlang-28.5.0.1-alpine-3.23.4,
-    1.17.3-erlang-27.3.4.12-alpine-3.23.4,
+    1.17.3-erlang-27.3.4.16-alpine-3.24.1,
     1.16.3-erlang-26.2.5.11-alpine-3.21.3
   ]
 


### PR DESCRIPTION
Update the Elixir 1.17 CircleCI image to OTP 27.3.4.16 and Alpine 3.24.1. This avoids an OTP 27 bug that is causing CI failures.